### PR TITLE
chore(export): update export options for the components in the library

### DIFF
--- a/components/article-wrap/stories/ArticleCategories.vue
+++ b/components/article-wrap/stories/ArticleCategories.vue
@@ -1,7 +1,7 @@
 <template>
   <ArticleWrap
     :date="['2017-04-03', '3 Apr. 2017']"
-    :contact="[contact]"
+    :contact="contact"
     :categories="['Sustainability','Tim Flannery', 'Melbourne Sustainable Society', 'Institute']"
     title="MGSE Professoriate Planning Day"
     type="speech"

--- a/components/article-wrap/stories/ArticleCategories.vue
+++ b/components/article-wrap/stories/ArticleCategories.vue
@@ -1,7 +1,7 @@
 <template>
   <ArticleWrap
     :date="['2017-04-03', '3 Apr. 2017']"
-    :contact="contact"
+    :contact="[contact]"
     :categories="['Sustainability','Tim Flannery', 'Melbourne Sustainable Society', 'Institute']"
     title="MGSE Professoriate Planning Day"
     type="speech"
@@ -13,10 +13,14 @@
     <BlockQuotation
       author="Steve Wozniak"
       border-top
-      border-bottom>Never trust a computer you can’t throw out a window.</BlockQuotation>
+      border-bottom
+    >Never trust a computer you can’t throw out a window.</BlockQuotation>
     <p>More recently, through courses including the Master of Clinical Teaching, the clinical teaching model has begun reaching a generation of practising teaching professionals and leaders, as well as helping shape new teachers who are just beginning their classroom careers.</p>
     <p>It is important to note also that this School inherits a great tradition of education practice and scholarship, through 20 years of leadership by Dean and later Vice-Chancellor Professor Kwong Lee Dow. Since departing as dean Kwong has been a recognised leader of education debate and policy-making – embodying the idea of scholarly engagement in the community. He remains a role model for what a great engaged school and faculty of education can be.</p>
-    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series <em>Revolution School</em> is only one recent example.</p>
+    <p>
+      Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series
+      <em>Revolution School</em> is only one recent example.
+    </p>
     <p>With such a legacy to build on, it seems to me the ongoing discussions you are now having about the future vision for this School should proceed with enormous confidence and optimism.</p>
     <p>So what are some of the challenges you might face in as you contemplate the future? A couple of broad questions might be relevant here.</p>
     <p>The first concerns the way education in general, and schools in particular, are increasingly being asked to sort out and settle a wide number of social problems – to solve all ills from the economic to the social and political; even health problems. How are teachers and educational leaders being prepared for the position of great social responsibility this places on their shoulders?</p>
@@ -28,9 +32,12 @@
 <script>
 import ArticleWrap from '../ArticleWrap.vue';
 import BlockQuotation from '../../block-quotation/BlockQuotation.vue';
+import article from './article.md';
 
 export default {
   components: { ArticleWrap, BlockQuotation },
+  readme: { custom: article, source: true, html: true },
+
   data() {
     return {
       contact: {

--- a/components/article-wrap/stories/ArticleCategoriesTags.vue
+++ b/components/article-wrap/stories/ArticleCategoriesTags.vue
@@ -13,16 +13,20 @@
     <BlockQuotation
       author="Steve Wozniak"
       border-top
-      border-bottom>Never trust a computer you can’t throw out a window.</BlockQuotation>
+      border-bottom
+    >Never trust a computer you can’t throw out a window.</BlockQuotation>
     <p>More recently, through courses including the Master of Clinical Teaching, the clinical teaching model has begun reaching a generation of practising teaching professionals and leaders, as well as helping shape new teachers who are just beginning their classroom careers.</p>
     <p>It is important to note also that this School inherits a great tradition of education practice and scholarship, through 20 years of leadership by Dean and later Vice-Chancellor Professor Kwong Lee Dow. Since departing as dean Kwong has been a recognised leader of education debate and policy-making – embodying the idea of scholarly engagement in the community. He remains a role model for what a great engaged school and faculty of education can be.</p>
-    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series <em>Revolution School</em> is only one recent example.</p>
+    <p>
+      Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series
+      <em>Revolution School</em> is only one recent example.
+    </p>
     <p>With such a legacy to build on, it seems to me the ongoing discussions you are now having about the future vision for this School should proceed with enormous confidence and optimism.</p>
     <p>So what are some of the challenges you might face in as you contemplate the future? A couple of broad questions might be relevant here.</p>
     <p>The first concerns the way education in general, and schools in particular, are increasingly being asked to sort out and settle a wide number of social problems – to solve all ills from the economic to the social and political; even health problems. How are teachers and educational leaders being prepared for the position of great social responsibility this places on their shoulders?</p>
     <p>The second concerns the multifaceted and rapid technological change of very recent years, and the impacts of this change on how we learn and how we teach. How important is technological change to learning? As a university and as a school, are we doing all we can to lead a way into the future in response to this question?</p>
     <p>The many experts present today will have answers to these questions. But I at least suggest that we need not be afraid of the possibilities for school or university in the face of technology.</p>
-    <Tags />
+    <Tags/>
   </ArticleWrap>
 </template>
 
@@ -30,9 +34,12 @@
 import ArticleWrap from '../ArticleWrap.vue';
 import BlockQuotation from '../../block-quotation/BlockQuotation.vue';
 import Tags from './Tags.vue';
+import article from './article.md';
 
 export default {
   components: { ArticleWrap, BlockQuotation, Tags },
+  readme: { custom: article, source: true, html: true },
+
   data() {
     return {
       contact: {

--- a/components/article-wrap/stories/ArticleWrapColumnLayout.vue
+++ b/components/article-wrap/stories/ArticleWrapColumnLayout.vue
@@ -6,16 +6,21 @@
     type="speech"
     column-layout
   >
-    <p class="lead">Thank you Johanna. It is a great pleasure to be here, and I am honoured to ask to start off a day of serious discussions.</p>
+    <p
+      class="lead"
+    >Thank you Johanna. It is a great pleasure to be here, and I am honoured to ask to start off a day of serious discussions.</p>
     <p>I’m conscious of what an important time this is with the departure of an outstanding leader in Professor Field Rickards. His contribution in 13 years as Dean (and indeed 43 years at the University) includes the transformation of the Faculty of Education into the MGSE and the reorganisation of professional teacher education at Melbourne, which has resulted in the school achieving stellar international rankings.</p>
     <p>From a wider University perspective, Field and the School have played an important role in shaping the Melbourne Curriculum (sometimes known as the Melbourne Model), with the Master of Teaching undoubtedly one its flagship degrees.</p>
     <BlockQuotation
       author="Steve Wozniak"
       border-top
-      border-bottom>Never trust a computer you can’t throw out a window.</BlockQuotation>
+      border-bottom
+    >Never trust a computer you can’t throw out a window.</BlockQuotation>
     <p>More recently, through courses including the Master of Clinical Teaching, the clinical teaching model has begun reaching a generation of practising teaching professionals and leaders, as well as helping shape new teachers who are just beginning their classroom careers.</p>
     <p>It is important to note also that this School inherits a great tradition of education practice and scholarship, through 20 years of leadership by Dean and later Vice-Chancellor Professor Kwong Lee Dow. Since departing as dean Kwong has been a recognised leader of education debate and policy-making – embodying the idea of scholarly engagement in the community. He remains a role model for what a great engaged school and faculty of education can be.</p>
-    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series <em>Revolution School</em> is only one recent example.</p>
+    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series
+      <em>Revolution School</em> is only one recent example.
+    </p>
     <p>With such a legacy to build on, it seems to me the ongoing discussions you are now having about the future vision for this School should proceed with enormous confidence and optimism.</p>
     <p>So what are some of the challenges you might face in as you contemplate the future? A couple of broad questions might be relevant here.</p>
     <p>The first concerns the way education in general, and schools in particular, are increasingly being asked to sort out and settle a wide number of social problems – to solve all ills from the economic to the social and political; even health problems. How are teachers and educational leaders being prepared for the position of great social responsibility this places on their shoulders?</p>
@@ -27,9 +32,12 @@
 <script>
 import ArticleWrap from '../ArticleWrap.vue';
 import BlockQuotation from '../../block-quotation/BlockQuotation.vue';
+import article from './article.md';
 
 export default {
   components: { ArticleWrap, BlockQuotation },
+  readme: { custom: article, source: true, html: true },
+
   data() {
     return {
       contact: {

--- a/components/article-wrap/stories/ArticleWrapDefault.vue
+++ b/components/article-wrap/stories/ArticleWrapDefault.vue
@@ -12,10 +12,13 @@
     <BlockQuotation
       author="Steve Wozniak"
       border-top
-      border-bottom>Never trust a computer you can’t throw out a window.</BlockQuotation>
+      border-bottom
+    >Never trust a computer you can’t throw out a window.</BlockQuotation>
     <p>More recently, through courses including the Master of Clinical Teaching, the clinical teaching model has begun reaching a generation of practising teaching professionals and leaders, as well as helping shape new teachers who are just beginning their classroom careers.</p>
     <p>It is important to note also that this School inherits a great tradition of education practice and scholarship, through 20 years of leadership by Dean and later Vice-Chancellor Professor Kwong Lee Dow. Since departing as dean Kwong has been a recognised leader of education debate and policy-making – embodying the idea of scholarly engagement in the community. He remains a role model for what a great engaged school and faculty of education can be.</p>
-    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series <em>Revolution School</em> is only one recent example.</p>
+    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series
+      <em>Revolution School</em> is only one recent example.
+    </p>
     <p>With such a legacy to build on, it seems to me the ongoing discussions you are now having about the future vision for this School should proceed with enormous confidence and optimism.</p>
     <p>So what are some of the challenges you might face in as you contemplate the future? A couple of broad questions might be relevant here.</p>
     <p>The first concerns the way education in general, and schools in particular, are increasingly being asked to sort out and settle a wide number of social problems – to solve all ills from the economic to the social and political; even health problems. How are teachers and educational leaders being prepared for the position of great social responsibility this places on their shoulders?</p>
@@ -27,9 +30,12 @@
 <script>
 import ArticleWrap from '../ArticleWrap.vue';
 import BlockQuotation from '../../block-quotation/BlockQuotation.vue';
+import article from './article.md';
 
 export default {
   components: { ArticleWrap, BlockQuotation },
+  readme: { custom: article, source: true, html: true },
+
   data() {
     return {
       contact: {

--- a/components/article-wrap/stories/ArticleWrapNoMetadata.vue
+++ b/components/article-wrap/stories/ArticleWrapNoMetadata.vue
@@ -6,10 +6,14 @@
     <BlockQuotation
       author="Steve Wozniak"
       border-top
-      border-bottom>Never trust a computer you can’t throw out a window.</BlockQuotation>
+      border-bottom
+    >Never trust a computer you can’t throw out a window.</BlockQuotation>
     <p>More recently, through courses including the Master of Clinical Teaching, the clinical teaching model has begun reaching a generation of practising teaching professionals and leaders, as well as helping shape new teachers who are just beginning their classroom careers.</p>
     <p>It is important to note also that this School inherits a great tradition of education practice and scholarship, through 20 years of leadership by Dean and later Vice-Chancellor Professor Kwong Lee Dow. Since departing as dean Kwong has been a recognised leader of education debate and policy-making – embodying the idea of scholarly engagement in the community. He remains a role model for what a great engaged school and faculty of education can be.</p>
-    <p>Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series <em>Revolution School</em> is only one recent example.</p>
+    <p>
+      Scholarly engagement in the community is something which remains characteristic of the Melbourne Graduate School of Education to the present day. Last year’s successful ABC television series
+      <em>Revolution School</em> is only one recent example.
+    </p>
     <p>With such a legacy to build on, it seems to me the ongoing discussions you are now having about the future vision for this School should proceed with enormous confidence and optimism.</p>
     <p>So what are some of the challenges you might face in as you contemplate the future? A couple of broad questions might be relevant here.</p>
     <p>The first concerns the way education in general, and schools in particular, are increasingly being asked to sort out and settle a wide number of social problems – to solve all ills from the economic to the social and political; even health problems. How are teachers and educational leaders being prepared for the position of great social responsibility this places on their shoulders?</p>
@@ -24,5 +28,6 @@ import BlockQuotation from '../../block-quotation/BlockQuotation.vue';
 
 export default {
   components: { ArticleWrap, BlockQuotation },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/article-wrap/stories/article.md
+++ b/components/article-wrap/stories/article.md
@@ -1,0 +1,7 @@
+## Article
+
+**Note**: Inside of `<article-wrap>` component the `contact` property is an object.
+
+Eg:
+
+`{ name: "John Robertson", phone: "+613 4234 2344", email: "john.robertson@unimelb.edu.au" }`

--- a/components/block-quotation/stories/BlockQuotationAltBg.vue
+++ b/components/block-quotation/stories/BlockQuotationAltBg.vue
@@ -8,6 +8,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml', bg: 'alt' },
 };

--- a/components/block-quotation/stories/BlockQuotationDefault.vue
+++ b/components/block-quotation/stories/BlockQuotationDefault.vue
@@ -8,6 +8,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml' },
 };

--- a/components/block-quotation/stories/BlockQuotationInverted.vue
+++ b/components/block-quotation/stories/BlockQuotationInverted.vue
@@ -8,6 +8,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml', bg: 'inverted' },
 };

--- a/components/block-quotation/stories/BlockQuotationInvertedWithBorders.vue
+++ b/components/block-quotation/stories/BlockQuotationInvertedWithBorders.vue
@@ -3,9 +3,7 @@
     author="Homer Simpson"
     border-top
     border-bottom
-  >
-    The Internet? Is that thing still around?
-  </BlockQuotation>
+  >The Internet? Is that thing still around?</BlockQuotation>
 </template>
 
 <script>
@@ -14,6 +12,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml', bg: 'inverted' },
 };

--- a/components/block-quotation/stories/BlockQuotationLong.vue
+++ b/components/block-quotation/stories/BlockQuotationLong.vue
@@ -1,5 +1,7 @@
 <template>
-  <BlockQuotation class="long">Great jobs numbers and finally, after many years, rising wages- and nobody even talks about them. Only Russia, Russia, Russia, despite the fact that, after a year of looking, there is No Collusion! 🇷🇺</BlockQuotation>
+  <BlockQuotation
+    class="long"
+  >Great jobs numbers and finally, after many years, rising wages- and nobody even talks about them. Only Russia, Russia, Russia, despite the fact that, after a year of looking, there is No Collusion! 🇷🇺</BlockQuotation>
 </template>
 
 <script>
@@ -8,6 +10,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml' },
 };

--- a/components/block-quotation/stories/BlockQuotationNoAuthor.vue
+++ b/components/block-quotation/stories/BlockQuotationNoAuthor.vue
@@ -8,6 +8,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml' },
 };

--- a/components/block-quotation/stories/BlockQuotationRaw.vue
+++ b/components/block-quotation/stories/BlockQuotationRaw.vue
@@ -10,6 +10,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   decorator: ContentBlock,
+  readme: { source: true, html: true },
   decoratorProps: { size: 'sml' },
 };
 </script>

--- a/components/block-quotation/stories/BlockQuotationWithBorders.vue
+++ b/components/block-quotation/stories/BlockQuotationWithBorders.vue
@@ -3,9 +3,7 @@
     author="Homer Simpson"
     border-top
     border-bottom
-  >
-    The Internet? Is that thing still around?
-  </BlockQuotation>
+  >The Internet? Is that thing still around?</BlockQuotation>
 </template>
 
 <script>
@@ -14,6 +12,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { BlockQuotation },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
   decoratorProps: { size: 'sml' },
 };

--- a/components/buttons/stories/Story1.vue
+++ b/components/buttons/stories/Story1.vue
@@ -3,13 +3,22 @@
     <ButtonIcon href="www.google.com">I am a button with an icon</ButtonIcon>
     <div class="grid">
       <div class="cell cell--tab-1of4">
-        <ButtonIcon href="www.google.com">I am a button with an icon and the name is super long to make it wrap onto the next line</ButtonIcon>
+        <ButtonIcon
+          href="www.google.com"
+        >I am a button with an icon and the name is super long to make it wrap onto the next line</ButtonIcon>
       </div>
       <div class="cell cell--tab-1of4">
         <ButtonIcon
           top
-          href="www.google.com">I am a button with an icon and the name is super long, the icon is top aligned</ButtonIcon>
+          href="www.google.com"
+        >I am a button with an icon and the name is super long, the icon is top aligned</ButtonIcon>
       </div>
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story10.vue
+++ b/components/buttons/stories/Story10.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon element="button">I am a button with no icon</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story11.vue
+++ b/components/buttons/stories/Story11.vue
@@ -6,3 +6,9 @@
     <button class="btn btn--icon btn--icon--twitter">Button with twitter icon</button>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story12.vue
+++ b/components/buttons/stories/Story12.vue
@@ -3,3 +3,9 @@
     <ButtonIcon inverted>I am an inverted button</ButtonIcon>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story13.vue
+++ b/components/buttons/stories/Story13.vue
@@ -6,3 +6,9 @@
     <button class="btn btn--icon-before btn--icon--twitter">Button with twitter icon</button>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story14.vue
+++ b/components/buttons/stories/Story14.vue
@@ -12,3 +12,9 @@
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story15.vue
+++ b/components/buttons/stories/Story15.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon class="btn--cta">Call to Action</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story2.vue
+++ b/components/buttons/stories/Story2.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon no-icon>I am a button with no icon</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story3.vue
+++ b/components/buttons/stories/Story3.vue
@@ -9,3 +9,9 @@
     <ButtonIcon icon="chevron-down">I am a button with an icon</ButtonIcon>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story4.vue
+++ b/components/buttons/stories/Story4.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon size="sml">I am a button with no icon</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story5.vue
+++ b/components/buttons/stories/Story5.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon size="xsml">I am a extra small button</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story6.vue
+++ b/components/buttons/stories/Story6.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon width="wide">I am a button with no icon</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story7.vue
+++ b/components/buttons/stories/Story7.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon width="xwide">I am a button with no icon</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story8.vue
+++ b/components/buttons/stories/Story8.vue
@@ -1,3 +1,9 @@
 <template>
   <ButtonIcon width="fullwidth">I am a button that stretches to the width of the parent</ButtonIcon>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/Story9.vue
+++ b/components/buttons/stories/Story9.vue
@@ -10,3 +10,9 @@
       size="xsml">I am a button with width and height modifiers</ButtonIcon>
   </div>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/cards/stories/GenericCard/Story1.vue
+++ b/components/cards/stories/GenericCard/Story1.vue
@@ -4,14 +4,12 @@
       <ListItem>
         <GenericCard
           :cols="2"
-          title="Test 1"
-        />
+          title="Test 1"/>
       </ListItem>
       <ListItem>
         <GenericCard
           :cols="2"
-          title="Test 1"
-        />
+          title="Test 1"/>
       </ListItem>
     </div>
   </SectionWrap>
@@ -19,10 +17,10 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>

--- a/components/cards/stories/GenericCard/Story2.vue
+++ b/components/cards/stories/GenericCard/Story2.vue
@@ -4,20 +4,17 @@
       <ListItem>
         <GenericCard
           :cols="3"
-          title="Test 1"
-        />
+          title="Test 1"/>
       </ListItem>
       <ListItem>
         <GenericCard
           :cols="3"
-          title="Test 1"
-        />
+          title="Test 1"/>
       </ListItem>
       <ListItem>
         <GenericCard
           :cols="3"
-          title="Test 1"
-        />
+          title="Test 1"/>
       </ListItem>
     </div>
   </SectionWrap>
@@ -25,8 +22,10 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
+import genericCardDoc from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
+  readme: { custom: genericCardDoc },
 };
 </script>

--- a/components/cards/stories/GenericCard/Story2.vue
+++ b/components/cards/stories/GenericCard/Story2.vue
@@ -22,10 +22,10 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>

--- a/components/cards/stories/GenericCard/Story3.vue
+++ b/components/cards/stories/GenericCard/Story3.vue
@@ -18,11 +18,11 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>
 

--- a/components/cards/stories/GenericCard/Story3.vue
+++ b/components/cards/stories/GenericCard/Story3.vue
@@ -4,8 +4,7 @@
       <ListItem>
         <GenericCard
           :cols="3"
-          title="Test 1"
-        >
+          title="Test 1">
           <div
             slot="sub-title-1"
             class="sub-title">
@@ -19,16 +18,18 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
+import genericCardDoc from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
+  readme: { custom: genericCardDoc },
 };
 </script>
 
 <style>
-  .sub-title {
-    display: flex;
-    align-items: center;
-    margin: 0;
-  }
+.sub-title {
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
 </style>

--- a/components/cards/stories/GenericCard/Story4.vue
+++ b/components/cards/stories/GenericCard/Story4.vue
@@ -19,11 +19,11 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>
 

--- a/components/cards/stories/GenericCard/Story4.vue
+++ b/components/cards/stories/GenericCard/Story4.vue
@@ -4,13 +4,11 @@
       <ListItem>
         <GenericCard
           :cols="2"
-          title="Test 1"
-        >
+          title="Test 1">
           <div
             slot="sub-title-1"
             class="sub-title">
-            <SvgIcon
-              name="calendar" />
+            <SvgIcon name="calendar"/>
             <span>Lorem ipsum</span>
           </div>
         </GenericCard>
@@ -21,20 +19,22 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
+import genericCardDoc from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
+  readme: { custom: genericCardDoc },
 };
 </script>
 
 <style>
-  .sub-title {
-    display: flex;
-    align-items: center;
-    margin: 0;
+.sub-title {
+  display: flex;
+  align-items: center;
+  margin: 0;
 
-    svg {
-      margin: 0 5px 0 0;
-    }
+  svg {
+    margin: 0 5px 0 0;
   }
+}
 </style>

--- a/components/cards/stories/GenericCard/Story5.vue
+++ b/components/cards/stories/GenericCard/Story5.vue
@@ -29,11 +29,11 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>
 <style>

--- a/components/cards/stories/GenericCard/Story5.vue
+++ b/components/cards/stories/GenericCard/Story5.vue
@@ -4,8 +4,7 @@
       <ListItem>
         <GenericCard
           :cols="2"
-          title="Test 1"
-        >
+          title="Test 1">
           <div
             slot="sub-title-1"
             class="sub-title">
@@ -14,8 +13,7 @@
           <div
             slot="sub-title-2"
             class="sub-title">
-            <SvgIcon
-              name="calendar" />
+            <SvgIcon name="calendar"/>
             <span>March 31 1992</span>
           </div>
           <div
@@ -31,16 +29,17 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
+import genericCardDoc from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
+  readme: { custom: genericCardDoc },
 };
 </script>
-
 <style>
-  .sub-title {
-    display: flex;
-    align-items: center;
-    margin: 0;
-  }
+.sub-title {
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
 </style>

--- a/components/cards/stories/GenericCard/Story6.vue
+++ b/components/cards/stories/GenericCard/Story6.vue
@@ -17,10 +17,10 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
-import genericCardDoc from './generic-card-docs.md';
+import genericCardDocs from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
-  readme: { custom: genericCardDoc },
+  readme: { custom: genericCardDocs },
 };
 </script>

--- a/components/cards/stories/GenericCard/Story6.vue
+++ b/components/cards/stories/GenericCard/Story6.vue
@@ -4,10 +4,8 @@
       <ListItem>
         <GenericCard
           :cols="3"
-          title="Test 1"
-        >
-          <template
-            slot="links">
+          title="Test 1">
+          <template slot="links">
             <a href="/">View generic details ></a>
             <a href="/">View generic staff ></a>
           </template>
@@ -19,8 +17,10 @@
 
 <script>
 import GenericCard from '../../GenericCard.vue';
+import genericCardDoc from './generic-card-docs.md';
 
 export default {
   components: { GenericCard },
+  readme: { custom: genericCardDoc },
 };
 </script>

--- a/components/cards/stories/GenericCard/generic-card-docs.md
+++ b/components/cards/stories/GenericCard/generic-card-docs.md
@@ -1,28 +1,42 @@
-The Generic Card component can be create with 3 times of view (1/2/3 columns).
-The component props (thumb/title/cols/href/excerpt);
-You can add only 3 sub-titles in slots (sub-title-1/sub-title-2/sub-title-3/). Other sub-title slots will not render.
-Cols props can more then 0 and less then 3.
+## Generic Card Component
+
+The Generic Card component can be create with in 3 different options of views `(1/2/3 columns)`.
+
+The component props are
+
+- thumb
+- title
+- cols
+- href
+- excerpt
+
+You can add only 3 sub-titles in slots
+
+- sub-title-1
+- sub-title-2
+- sub-title-3
+
+> Other sub-title slots will not render.
+
+Cols props can be more then `0` and must be less then `3`.
+
 The component have one slot for links.
+
+### Usage Example
+
 ```html
 <SectionWrap class="bg-alt">
-    <div class="grid grid--2col">
-      <ListItem>
-        <GenericCard
-          :cols="2"
-          title="Test 1"
-        >
-          <!--Slots-->
-        </GenericCard>
-      </ListItem>
-      <ListItem>
-        <GenericCard
-          :cols="2"
-          title="Test 1"
-        >
-          <!--Slots-->
-        </GenericCard>
-      </ListItem>
-    </div>
-  </SectionWrap>
-
+  <div class="grid grid--2col">
+    <ListItem>
+      <GenericCard :cols="2" title="Test 1">
+        <!--Slots-->
+      </GenericCard>
+    </ListItem>
+    <ListItem>
+      <GenericCard :cols="2" title="Test 1">
+        <!--Slots-->
+      </GenericCard>
+    </ListItem>
+  </div>
+</SectionWrap>
 ```

--- a/components/cards/stories/GenericCard/generic-card-docs.md
+++ b/components/cards/stories/GenericCard/generic-card-docs.md
@@ -1,6 +1,6 @@
 ## Generic Card Component
 
-The Generic Card component can be create with in 3 different options of views `(1/2/3 columns)`.
+The Generic Card component can be created within 3 different options of views `(1/2/3 columns)`.
 
 The component props are
 
@@ -20,7 +20,7 @@ You can add only 3 sub-titles in slots
 
 Cols props can be more then `0` and must be less then `3`.
 
-The component have one slot for links.
+The component has one slot for links.
 
 ### Usage Example
 

--- a/components/contact-list/stories/ContactListDefault.vue
+++ b/components/contact-list/stories/ContactListDefault.vue
@@ -2,8 +2,7 @@
   <ContactList
     name="John Smith"
     phone="+613 4234 2344"
-    email="john.smith@unimelb.edu.au"
-  />
+    email="john.smith@unimelb.edu.au"/>
 </template>
 
 <script>
@@ -11,5 +10,6 @@ import ContactList from '../ContactList.vue';
 
 export default {
   components: { ContactList },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/contact-list/stories/ContactListLongDetails.vue
+++ b/components/contact-list/stories/ContactListLongDetails.vue
@@ -12,6 +12,7 @@ import MaxWidthDecorator from '../../../.storybook/decorators/MaxWidthDecorator.
 
 export default {
   components: { ContactList },
+  readme: { source: true, html: true },
   decorator: MaxWidthDecorator,
   decoratorProps: { maxWidth: 13 },
 };

--- a/components/content-block/stories/ContentBlockDefault.vue
+++ b/components/content-block/stories/ContentBlockDefault.vue
@@ -11,5 +11,6 @@ import ContentBlock from '../ContentBlock.vue';
 
 export default {
   components: { ContentBlock },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/content-block/stories/ContentBlockLargeInverted.vue
+++ b/components/content-block/stories/ContentBlockLargeInverted.vue
@@ -13,5 +13,6 @@ import ContentBlock from '../ContentBlock.vue';
 
 export default {
   components: { ContentBlock },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/content-block/stories/ContentBlockNews.vue
+++ b/components/content-block/stories/ContentBlockNews.vue
@@ -3,11 +3,13 @@
     <li class="news-block__item">
       <a
         class="news-block__link"
-        href="http://newsroom.melbourne.edu/news/respect-now-always-university-melbourne-data">
+        href="http://newsroom.melbourne.edu/news/respect-now-always-university-melbourne-data"
+      >
         <img
           class="news-block__img"
-          alt=""
-          src="http://cms.unimelb.edu.au/__data/assets/image/0012/2649765/respect-reflection-pool-tile.jpg">
+          alt
+          src="http://cms.unimelb.edu.au/__data/assets/image/0012/2649765/respect-reflection-pool-tile.jpg"
+        >
         <h4 class="news-block__title">Respect. Now. Always</h4>
         <p>Access survey data, watch the VC speaking out against sexual assault and harassment on campus.</p>
       </a>
@@ -15,11 +17,13 @@
     <li class="news-block__item">
       <a
         class="news-block__link"
-        href="http://melbournemodel.unimelb.edu.au/?in_c=hpbanner%7Cer_2017_brand_melbmodel">
+        href="http://melbournemodel.unimelb.edu.au/?in_c=hpbanner%7Cer_2017_brand_melbmodel"
+      >
         <img
           class="news-block__img"
-          alt=""
-          src="http://cms.unimelb.edu.au/__data/assets/image/0004/2649766/brand-tile.jpg">
+          alt
+          src="http://cms.unimelb.edu.au/__data/assets/image/0004/2649766/brand-tile.jpg"
+        >
         <h4 class="news-block__title">Talent for every possible future</h4>
         <p>Meet our Melbourne Model graduates</p>
       </a>
@@ -27,11 +31,13 @@
     <li class="news-block__item">
       <a
         class="news-block__link"
-        href="https://shop.unimelb.edu.au/?utm_source=unimelb.edu.au&utm_medium=referral&utm_content=homepage">
+        href="https://shop.unimelb.edu.au/?utm_source=unimelb.edu.au&utm_medium=referral&utm_content=homepage"
+      >
         <img
           class="news-block__img"
-          alt=""
-          src="http://cms.unimelb.edu.au/__data/assets/image/0008/2649653/visitor-centre.jpg">
+          alt
+          src="http://cms.unimelb.edu.au/__data/assets/image/0008/2649653/visitor-centre.jpg"
+        >
         <h4 class="news-block__title">Visitor Centre and Shop now open</h4>
         <p>Get your campus map and check out our official merchandise</p>
       </a>

--- a/components/content-block/stories/ContentBlockNewsEvents.vue
+++ b/components/content-block/stories/ContentBlockNewsEvents.vue
@@ -4,27 +4,37 @@
       <div class="grid">
         <div class="cell cell--desk-2of3">
           <h3 class="heading-lead shim-pb1">Featured news</h3>
-          <ContentBlockNews />
-          <a href="">View more news<svg
-            width="15px"
-            height="15px"
-            focusable="false"
-            role="presentation"
-            class="push-icon__icon"><use
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-              xlink:href="#icon-chevron-right" /></svg></a>
+          <ContentBlockNews/>
+          <a href>View more news
+            <svg
+              width="15px"
+              height="15px"
+              focusable="false"
+              role="presentation"
+              class="push-icon__icon"
+            >
+              <use
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="#icon-chevron-right"/>
+            </svg>
+          </a>
         </div>
         <div class="cell cell--desk-1of3">
           <h3 class="heading-lead shim-pb1">Upcoming events</h3>
-          <ContentBlockEvent class="bg-alt-darker" />
-          <a href="">View more events<svg
-            width="15px"
-            height="15px"
-            focusable="false"
-            role="presentation"
-            class="push-icon__icon"><use
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-              xlink:href="#icon-chevron-right" /></svg></a>
+          <ContentBlockEvent class="bg-alt-darker"/>
+          <a href>View more events
+            <svg
+              width="15px"
+              height="15px"
+              focusable="false"
+              role="presentation"
+              class="push-icon__icon"
+            >
+              <use
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="#icon-chevron-right"/>
+            </svg>
+          </a>
         </div>
       </div>
     </div>
@@ -37,5 +47,6 @@ import ContentBlockEvent from './ContentBlockEvent.vue';
 
 export default {
   components: { ContentBlockNews, ContentBlockEvent },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/content-block/stories/ContentBlockShortAlt.vue
+++ b/components/content-block/stories/ContentBlockShortAlt.vue
@@ -3,7 +3,9 @@
     bg="alt"
     short>
     <h2>Example Title</h2>
-    <p class="lead">As one of the world’s leading universities, we aspire to build on our distinguished traditions and create an innovative future.</p>
+    <p
+      class="lead"
+    >As one of the world’s leading universities, we aspire to build on our distinguished traditions and create an innovative future.</p>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab adipisci alias, cumque, esse incidunt consequatur, accusantium odit blanditiis ipsam dolorem repellendus ut corporis earum, illum a maiores optio voluptate dicta.</p>
   </ContentBlock>
 </template>
@@ -13,5 +15,6 @@ import ContentBlock from '../ContentBlock.vue';
 
 export default {
   components: { ContentBlock },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/content-block/stories/ContentBlockSmall.vue
+++ b/components/content-block/stories/ContentBlockSmall.vue
@@ -1,7 +1,9 @@
 <template>
   <ContentBlock size="sml">
     <h2>Example Title</h2>
-    <p class="lead">As one of the world’s leading universities, we aspire to build on our distinguished traditions and create an innovative future.</p>
+    <p
+      class="lead"
+    >As one of the world’s leading universities, we aspire to build on our distinguished traditions and create an innovative future.</p>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab adipisci alias, cumque, esse incidunt consequatur, accusantium odit blanditiis ipsam dolorem repellendus ut corporis earum, illum a maiores optio voluptate dicta.</p>
   </ContentBlock>
 </template>
@@ -11,5 +13,6 @@ import ContentBlock from '../ContentBlock.vue';
 
 export default {
   components: { ContentBlock },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/document-list/stories/Story3.vue
+++ b/components/document-list/stories/Story3.vue
@@ -6,7 +6,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -16,7 +16,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -26,7 +26,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>

--- a/components/document-list/stories/Story4.vue
+++ b/components/document-list/stories/Story4.vue
@@ -6,7 +6,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -16,7 +16,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -26,7 +26,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -36,7 +36,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>
@@ -46,7 +46,7 @@
           <figure>
             <img
               src="https://picsum.photos/300/400?gravity=center"
-              alt="">
+              alt="alt text goes here">
             <figcaption>2016 Annual Report (PDF File 6.8 MB)</figcaption>
           </figure>
         </a>

--- a/components/dropdown/stories/DropdownDefault.vue
+++ b/components/dropdown/stories/DropdownDefault.vue
@@ -9,5 +9,6 @@ import Dropdown from '../Dropdown.vue';
 
 export default {
   components: { Dropdown },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/embed/stories/SoundcloudClassic.vue
+++ b/components/embed/stories/SoundcloudClassic.vue
@@ -10,6 +10,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { SoundcloudEmbed },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
 };
 </script>

--- a/components/embed/stories/SoundcloudVisual.vue
+++ b/components/embed/stories/SoundcloudVisual.vue
@@ -11,6 +11,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { SoundcloudEmbed },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
 };
 </script>

--- a/components/embed/stories/Video16By9.vue
+++ b/components/embed/stories/Video16By9.vue
@@ -1,5 +1,5 @@
 <template>
-  <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI" />
+  <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI"/>
 </template>
 
 <script>
@@ -8,6 +8,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { VideoEmbed },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
 };
 </script>

--- a/components/embed/stories/Video21By9.vue
+++ b/components/embed/stories/Video21By9.vue
@@ -1,8 +1,7 @@
 <template>
   <VideoEmbed
     src="https://www.youtube.com/embed/nlF7qp5GNPI"
-    ratio="21_9"
-  />
+    ratio="21_9"/>
 </template>
 
 <script>
@@ -11,6 +10,7 @@ import ContentBlock from '../../content-block/ContentBlock.vue';
 
 export default {
   components: { VideoEmbed },
+  readme: { source: true, html: true },
   decorator: ContentBlock,
 };
 </script>

--- a/components/embed/stories/VideoInContentBlock.vue
+++ b/components/embed/stories/VideoInContentBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI" />
+  <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI"/>
 </template>
 
 <script>
@@ -10,6 +10,6 @@ export default {
   components: { VideoEmbed },
   decorator: ContentBlock,
   decoratorProps: { bg: 'inverted', size: 'sml' },
-  readme: { decorated: true },
+  readme: { decorated: true, source: true, html: true },
 };
 </script>

--- a/components/embed/stories/VideoInSection.vue
+++ b/components/embed/stories/VideoInSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h3 class="heading-section">Section with video embed</h3>
-    <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI" />
+    <VideoEmbed src="https://www.youtube.com/embed/nlF7qp5GNPI"/>
   </div>
 </template>
 
@@ -13,6 +13,6 @@ export default {
   components: { VideoEmbed },
   decorator: SectionWrap,
   decoratorProps: { bgColor: 'inverted', centred: true },
-  readme: { decorated: true },
+  readme: { decorated: true, source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story1.vue
+++ b/components/figure/stories/Story1.vue
@@ -8,7 +8,7 @@
       <figure-wrap caption="embed test">
         <img
           src="https://picsum.photos/800/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Molestiae accusantium ducimus tempora delectus minima mollitia quia dicta alias. Fugiat magnam consequatur voluptatem sunt. Nesciunt est occaecati possimus quis iure architecto sunt.</p>
       <figure-wrap
@@ -16,7 +16,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/820/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>
         The example above uses the

--- a/components/figure/stories/Story1.vue
+++ b/components/figure/stories/Story1.vue
@@ -4,23 +4,24 @@
     short
     bg-color="white">
     <div>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap caption="embed test">
         <img
           src="https://picsum.photos/800/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>Molestiae accusantium ducimus tempora delectus minima mollitia quia dicta alias. Fugiat magnam consequatur voluptatem sunt. Nesciunt est occaecati possimus quis iure architecto sunt. </p>
+      <p>Molestiae accusantium ducimus tempora delectus minima mollitia quia dicta alias. Fugiat magnam consequatur voluptatem sunt. Nesciunt est occaecati possimus quis iure architecto sunt.</p>
       <figure-wrap
         fill
         caption="embed test">
         <img
           src="https://picsum.photos/820/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>The example above uses the <code>&lt;figure class="figure figure--fill"&gt;</code> variant, to completely fill the container with no padding left/right. </p>
+      <p>
+        The example above uses the
+        <code>&lt;figure class="figure figure--fill"&gt;</code> variant, to completely fill the container with no padding left/right.
+      </p>
     </div>
   </section-wrap>
 </template>
@@ -29,5 +30,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story10.vue
+++ b/components/figure/stories/Story10.vue
@@ -6,19 +6,15 @@
       bg-color="white">
       <div>
         <h2>Heading</h2>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           large
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -29,5 +25,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story10.vue
+++ b/components/figure/stories/Story10.vue
@@ -12,7 +12,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story11.vue
+++ b/components/figure/stories/Story11.vue
@@ -6,19 +6,15 @@
       bg-color="white">
       <div>
         <h2>Heading</h2>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           medium
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -29,5 +25,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story11.vue
+++ b/components/figure/stories/Story11.vue
@@ -12,7 +12,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story12.vue
+++ b/components/figure/stories/Story12.vue
@@ -6,19 +6,15 @@
       bg-color="white">
       <div>
         <h2>Heading</h2>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           small
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -29,5 +25,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story12.vue
+++ b/components/figure/stories/Story12.vue
@@ -12,7 +12,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story2.vue
+++ b/components/figure/stories/Story2.vue
@@ -4,18 +4,14 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         right
         caption="embed test">
         <img src="https://picsum.photos/600/400?random&gravity=center">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -25,5 +21,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story3.vue
+++ b/components/figure/stories/Story3.vue
@@ -4,20 +4,16 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         left
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -27,5 +23,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story3.vue
+++ b/components/figure/stories/Story3.vue
@@ -11,7 +11,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story4.vue
+++ b/components/figure/stories/Story4.vue
@@ -12,7 +12,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story4.vue
+++ b/components/figure/stories/Story4.vue
@@ -4,9 +4,7 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         small
@@ -14,11 +12,9 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -28,5 +24,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story5.vue
+++ b/components/figure/stories/Story5.vue
@@ -12,7 +12,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story5.vue
+++ b/components/figure/stories/Story5.vue
@@ -4,9 +4,7 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         small
@@ -14,11 +12,9 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -28,5 +24,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story6.vue
+++ b/components/figure/stories/Story6.vue
@@ -12,7 +12,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story6.vue
+++ b/components/figure/stories/Story6.vue
@@ -4,9 +4,7 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         large
@@ -14,11 +12,9 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -28,5 +24,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story7.vue
+++ b/components/figure/stories/Story7.vue
@@ -12,7 +12,7 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="test">
+          alt="alt text goes here">
       </figure-wrap>
       <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story7.vue
+++ b/components/figure/stories/Story7.vue
@@ -4,9 +4,7 @@
     bg-color="white">
     <div>
       <h2>Heading</h2>
-      <p>
-        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-      </p>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
       <figure-wrap
         inset
         large
@@ -14,11 +12,9 @@
         caption="embed test">
         <img
           src="https://picsum.photos/600/400?random&gravity=center"
-          alt="">
+          alt="test">
       </figure-wrap>
-      <p>
-        Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-      </p>
+      <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
       <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
     </div>
   </section-wrap>
@@ -28,5 +24,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story8.vue
+++ b/components/figure/stories/Story8.vue
@@ -6,9 +6,7 @@
       bg-color="white">
       <div>
         <h2>Heading</h2>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           large
@@ -16,11 +14,9 @@
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="">
+            alt="test">
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -29,20 +25,16 @@
       nopad
       bg-color="white">
       <div>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           left
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="">
+            alt="test">
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -51,9 +43,7 @@
       nopad
       bg-color="white">
       <div>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           small
@@ -61,11 +51,9 @@
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="">
+            alt="test">
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -76,5 +64,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/figure/stories/Story8.vue
+++ b/components/figure/stories/Story8.vue
@@ -14,7 +14,7 @@
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="test">
+            alt="alt text goes here">
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
@@ -32,7 +32,7 @@
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="test">
+            alt="alt text goes here">
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
@@ -51,7 +51,7 @@
           caption="embed test">
           <img
             src="https://picsum.photos/600/400?random&gravity=center"
-            alt="test">
+            alt="alt text goes here">
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story9.vue
+++ b/components/figure/stories/Story9.vue
@@ -14,7 +14,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
@@ -32,7 +33,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
@@ -51,7 +53,8 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/600?random&gravity=center"
-            alt="test"/>
+            alt="alt text goes here"
+          />
         </figure-wrap>
         <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>

--- a/components/figure/stories/Story9.vue
+++ b/components/figure/stories/Story9.vue
@@ -6,9 +6,7 @@
       bg-color="white">
       <div>
         <h2>Heading</h2>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           large
@@ -16,11 +14,9 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -29,20 +25,16 @@
       short
       bg-color="white">
       <div>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           left
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/400?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -51,9 +43,7 @@
       short
       bg-color="white">
       <div>
-        <p>
-          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.
-        </p>
+        <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Odit eum cum pariatur excepturi deleniti ipsum architecto possimus? Pariatur vitae, saepe magnam cupiditate earum cum, soluta mollitia repudiandae tempore, modi eos.</p>
         <figure-wrap
           inset
           small
@@ -61,11 +51,9 @@
           caption="embed test">
           <progressive-img
             src="https://picsum.photos/800/600?random&gravity=center"
-            alt=""/>
+            alt="test"/>
         </figure-wrap>
-        <p>
-          Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.
-        </p>
+        <p>Blanditiis exercitationem id sapiente voluptatem dolorum est sapiente. Qui explicabo voluptatem dolores perspiciatis laborum animi. Similique animi molestiae ipsam accusamus incidunt rerum. Et fugiat ut eum dolores id. Quaerat repudiandae facere voluptas fuga laboriosam quo illo adipisci. Doloremque autem cum ea voluptatem id.</p>
         <p>At aperiam porro. Voluptas alias harum. Repellendus quaerat modi laudantium sed corrupti alias et quibusdam. At quas quia quos vel et sit eum officia.</p>
       </div>
     </section-wrap>
@@ -76,6 +64,6 @@
 import FigureWrap from '../FigureWrap.vue';
 export default {
   components: { FigureWrap },
-  readme: { html: true },
+  readme: { html: true, source: true },
 };
 </script>

--- a/components/listing/stories/Container/LinkList.vue
+++ b/components/listing/stories/Container/LinkList.vue
@@ -3,13 +3,22 @@
     class="listing--links"
     cols="3">
     <ListItem>
-      <a href="https://coursesearch.unimelb.edu.au/undergrad"><h3>Undergraduate courses</h3> <p>An undergraduate course is your first degree at university. Search here if you’re a secondary school student, or looking to start your first degree at university.</p></a>
+      <a href="https://coursesearch.unimelb.edu.au/undergrad">
+        <h3>Undergraduate courses</h3>
+        <p>An undergraduate course is your first degree at university. Search here if you’re a secondary school student, or looking to start your first degree at university.</p>
+      </a>
     </ListItem>
     <ListItem>
-      <a href="https://coursesearch.unimelb.edu.au/grad"><h3>Graduate courses</h3> <p>Our graduate courses are ideal if you’re looking to get a professional masters qualification, develop specialist knowledge or undertake graduate research.</p></a>
+      <a href="https://coursesearch.unimelb.edu.au/grad">
+        <h3>Graduate courses</h3>
+        <p>Our graduate courses are ideal if you’re looking to get a professional masters qualification, develop specialist knowledge or undertake graduate research.</p>
+      </a>
     </ListItem>
     <ListItem>
-      <a href="https://online.unimelb.edu.au/"><h3>Online Graduate courses</h3> <p>A collection of specialist online masters, graduate certificate and diploma programs that will take your career to the next level.</p></a>
+      <a href="https://online.unimelb.edu.au/">
+        <h3>Online Graduate courses</h3>
+        <p>A collection of specialist online masters, graduate certificate and diploma programs that will take your career to the next level.</p>
+      </a>
     </ListItem>
   </ListingWrap>
 </template>
@@ -22,5 +31,6 @@ import SectionWrap from '../../../section/SectionWrap.vue';
 export default {
   components: { ListingWrap, ListItem },
   decorator: SectionWrap,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/listing/stories/Container/Story1.vue
+++ b/components/listing/stories/Container/Story1.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
   </ListingWrap>
 </template>
@@ -30,5 +30,6 @@ import SectionWrap from '../../../section/SectionWrap.vue';
 export default {
   components: { ListingWrap },
   decorator: SectionWrap,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/listing/stories/Container/Story1.vue
+++ b/components/listing/stories/Container/Story1.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
   </ListingWrap>
 </template>

--- a/components/listing/stories/Container/Story2.vue
+++ b/components/listing/stories/Container/Story2.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
   </ListingWrap>
 </template>

--- a/components/listing/stories/Container/Story2.vue
+++ b/components/listing/stories/Container/Story2.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
   </ListingWrap>
 </template>
@@ -31,5 +31,6 @@ import SectionWrap from '../../../section/SectionWrap.vue';
 export default {
   components: { ListingWrap, ListItem },
   decorator: SectionWrap,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/listing/stories/Container/Story3.vue
+++ b/components/listing/stories/Container/Story3.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
   </ListingWrap>
 </template>

--- a/components/listing/stories/Container/Story3.vue
+++ b/components/listing/stories/Container/Story3.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
   </ListingWrap>
 </template>
@@ -31,5 +31,6 @@ import SectionWrap from '../../../section/SectionWrap.vue';
 export default {
   components: { ListingWrap, ListItem },
   decorator: SectionWrap,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/listing/stories/Container/Story4.vue
+++ b/components/listing/stories/Container/Story4.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="test">
+        alt="alt text goes here">
     </ListItem>
   </ListingWrap>
 </template>

--- a/components/listing/stories/Container/Story4.vue
+++ b/components/listing/stories/Container/Story4.vue
@@ -3,22 +3,22 @@
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
     <ListItem>
       <img
         src="https://placehold.it/600x200"
-        alt="">
+        alt="test">
     </ListItem>
   </ListingWrap>
 </template>
@@ -31,5 +31,6 @@ import SectionWrap from '../../../section/SectionWrap.vue';
 export default {
   components: { ListingWrap, ListItem },
   decorator: SectionWrap,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/notice/stories/NoticeDanger.vue
+++ b/components/notice/stories/NoticeDanger.vue
@@ -1,6 +1,9 @@
 <template>
   <Notice level="danger">
-    <p><strong>Notice!</strong> Better check yourself before you <a href="#"> wreck </a> yourself</p>
+    <p>
+      <strong>Notice!</strong> Better check yourself before you
+      <a href="#">wreck</a> yourself
+    </p>
     <p>Dolor doloribus eos reiciendis. Mollitia tenetur quibusdam unde animi at laborum exercitationem.</p>
     <p>Dolor doloribus eos reiciendis. Mollitia tenetur quibusdam unde animi at laborum exercitationem.</p>
   </Notice>
@@ -11,5 +14,6 @@ import Notice from '../Notice.vue';
 
 export default {
   components: { Notice },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/notice/stories/NoticeDefault.vue
+++ b/components/notice/stories/NoticeDefault.vue
@@ -1,6 +1,8 @@
 <template>
   <Notice>
-    <span> <strong>Notice!</strong> Better check yourself before you wreck yourself</span>
+    <span>
+      <strong>Notice!</strong> Better check yourself before you wreck yourself
+    </span>
   </Notice>
 </template>
 
@@ -9,5 +11,6 @@ import Notice from '../Notice.vue';
 
 export default {
   components: { Notice },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/notice/stories/NoticeSuccess.vue
+++ b/components/notice/stories/NoticeSuccess.vue
@@ -1,6 +1,8 @@
 <template>
   <Notice level="success">
-    <span> <strong>Notice!</strong> Better check yourself before you wreck yourself</span>
+    <span>
+      <strong>Notice!</strong> Better check yourself before you wreck yourself
+    </span>
   </Notice>
 </template>
 
@@ -9,5 +11,6 @@ import Notice from '../Notice.vue';
 
 export default {
   components: { Notice },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/notice/stories/NoticeWarning.vue
+++ b/components/notice/stories/NoticeWarning.vue
@@ -1,6 +1,8 @@
 <template>
   <Notice level="warning">
-    <span> <strong>Notice!</strong> Better check yourself before you wreck yourself </span>
+    <span>
+      <strong>Notice!</strong> Better check yourself before you wreck yourself
+    </span>
   </Notice>
 </template>
 
@@ -9,5 +11,6 @@ import Notice from '../Notice.vue';
 
 export default {
   components: { Notice },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/breadcrumbs/stories/PageBreadcrumbsExtraLong.vue
+++ b/components/page/breadcrumbs/stories/PageBreadcrumbsExtraLong.vue
@@ -1,19 +1,28 @@
 <template>
-  <PageBreadcrumbs :items="items" />
+  <PageBreadcrumbs :items="items"/>
 </template>
 
 <script>
 import PageBreadcrumbs from '../PageBreadcrumbs.vue';
+import PageBreadcrumbsDocs from './page-breadcrumbs-docs.md';
 
 export default {
   components: { PageBreadcrumbs },
+  readme: { custom: PageBreadcrumbsDocs, source: true, html: true },
   data: () => ({
     items: [
       { href: '/', text: 'About us' },
       { href: '/strategy', text: 'Strategy and governance' },
       { href: '/strategy/growing-esteem', text: 'Growing Esteem' },
-      { href: '/strategy/growing-esteem/learning-and-teaching', text: 'Learning and teaching' },
-      { href: '/strategy/growing-esteem/learning-and-teaching/key-facts-and-figures', text: 'Key facts and figures' },
+      {
+        href: '/strategy/growing-esteem/learning-and-teaching',
+        text: 'Learning and teaching',
+      },
+      {
+        href:
+          '/strategy/growing-esteem/learning-and-teaching/key-facts-and-figures',
+        text: 'Key facts and figures',
+      },
     ],
   }),
 };

--- a/components/page/breadcrumbs/stories/PageBreadcrumbsLevel1.vue
+++ b/components/page/breadcrumbs/stories/PageBreadcrumbsLevel1.vue
@@ -1,16 +1,16 @@
 <template>
-  <PageBreadcrumbs :items="items" />
+  <PageBreadcrumbs :items="items"/>
 </template>
 
 <script>
 import PageBreadcrumbs from '../PageBreadcrumbs.vue';
+import PageBreadcrumbsDocs from './page-breadcrumbs-docs.md';
 
 export default {
   components: { PageBreadcrumbs },
+  readme: { custom: PageBreadcrumbsDocs, source: true, html: true },
   data: () => ({
-    items: [
-      { href: '/', text: 'About us' },
-    ],
+    items: [{ href: '/', text: 'About us' }],
   }),
 };
 </script>

--- a/components/page/breadcrumbs/stories/PageBreadcrumbsLevel2.vue
+++ b/components/page/breadcrumbs/stories/PageBreadcrumbsLevel2.vue
@@ -1,12 +1,14 @@
 <template>
-  <PageBreadcrumbs :items="items" />
+  <PageBreadcrumbs :items="items"/>
 </template>
 
 <script>
 import PageBreadcrumbs from '../PageBreadcrumbs.vue';
+import PageBreadcrumbsDocs from './page-breadcrumbs-docs.md';
 
 export default {
   components: { PageBreadcrumbs },
+  readme: { custom: PageBreadcrumbsDocs, source: true, html: true },
   data: () => ({
     items: [
       { href: '/', text: 'About us' },

--- a/components/page/breadcrumbs/stories/PageBreadcrumbsLevel3.vue
+++ b/components/page/breadcrumbs/stories/PageBreadcrumbsLevel3.vue
@@ -1,12 +1,14 @@
 <template>
-  <PageBreadcrumbs :items="items" />
+  <PageBreadcrumbs :items="items"/>
 </template>
 
 <script>
 import PageBreadcrumbs from '../PageBreadcrumbs.vue';
+import PageBreadcrumbsDocs from './page-breadcrumbs-docs.md';
 
 export default {
   components: { PageBreadcrumbs },
+  readme: { custom: PageBreadcrumbsDocs, source: true, html: true },
   data: () => ({
     items: [
       { href: '/', text: 'About us' },

--- a/components/page/breadcrumbs/stories/page-breadcrumbs-docs.md
+++ b/components/page/breadcrumbs/stories/page-breadcrumbs-docs.md
@@ -1,6 +1,6 @@
 ## Breadcrumbs
 
-The level of the `breadcrumbs` is decided by the object `items` that you send as a prop to the component.
+The level of the `breadcrumbs` is decided by the array `items` that you send as a prop to the component.
 
 - Example of the extra long:
 

--- a/components/page/breadcrumbs/stories/page-breadcrumbs-docs.md
+++ b/components/page/breadcrumbs/stories/page-breadcrumbs-docs.md
@@ -1,0 +1,24 @@
+## Breadcrumbs
+
+The level of the `breadcrumbs` is decided by the object `items` that you send as a prop to the component.
+
+- Example of the extra long:
+
+```
+items: [
+      { href: "/", text: "About us" },
+      { href: "/strategy", text: "Strategy and governance" },
+      { href: "/strategy/growing-esteem", text: "Growing Esteem" },
+      {
+        href: "/strategy/growing-esteem/learning-and-teaching",
+        text: "Learning and teaching"
+      },
+      {
+        href:
+          "/strategy/growing-esteem/learning-and-teaching/key-facts-and-figures",
+        text: "Key facts and figures"
+      }
+    ]
+```
+
+### Usage Example:

--- a/components/page/header/stories/level-1/Level1Default.vue
+++ b/components/page/header/stories/level-1/Level1Default.vue
@@ -1,8 +1,7 @@
 <template>
   <PageHeader
     title="About Us"
-    img="https://placeimg.com/990/530/arch/1"
-  />
+    img="https://placeimg.com/990/530/arch/1"/>
 </template>
 
 <script>
@@ -10,5 +9,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-1/Level1DualEntity.vue
+++ b/components/page/header/stories/level-1/Level1DualEntity.vue
@@ -12,5 +12,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-1/Level1Entity.vue
+++ b/components/page/header/stories/level-1/Level1Entity.vue
@@ -11,5 +11,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-1/Level1Home.vue
+++ b/components/page/header/stories/level-1/Level1Home.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header--campaign"
-    style="background-image:url(https://placeimg.com/990/530/arch/1)">
+    style="background-image:url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header">
       <div class="page-header__inner max">
         <a
@@ -19,7 +20,7 @@
       <div class="section__inner section__inner--xsml">
         <CardPathfinder
           titleonly
-          title="Talent for every<br>possible outcome" />
+          title="Talent for every<br>possible outcome"/>
       </div>
     </header>
   </div>
@@ -30,5 +31,6 @@ import CardPathfinder from '../../../../cards/CardPathfinder.vue';
 
 export default {
   components: { CardPathfinder },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-1/Level1HomeCampaignButton.vue
+++ b/components/page/header/stories/level-1/Level1HomeCampaignButton.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header--campaign"
-    style="background-image:url(https://placeimg.com/990/530/arch/1)">
+    style="background-image:url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header">
       <div class="page-header__inner max">
         <a
@@ -19,21 +20,20 @@
       <div class="page-header--baseline max max--xsml shim-pb2">
         <a
           class="btn btn--center btn--cta"
-          href=""><span class="push-icon">Call to action <svg
-            width="15px"
-            height="15px"
-            focusable="false"
-            role="presentation"
-            class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+          href>
+          <span class="push-icon">Call to action
+            <svg
+              width="15px"
+              height="15px"
+              focusable="false"
+              role="presentation"
+              class="push-icon__icon"
+            >
+              <use xlink:href="#icon-chevron-right"/>
+            </svg>
+          </span>
+        </a>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-1/Level1HomeCampaignNoLogo.vue
+++ b/components/page/header/stories/level-1/Level1HomeCampaignNoLogo.vue
@@ -1,30 +1,32 @@
 <template>
   <div
     class="page-header__darken--o50 page-header--campaign"
-    style="background-image: url(https://placeimg.com/990/530/arch/1)">
+    style="background-image: url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header page-header--l1 page-header--no-logo">
       <div class="page-header--center">
         <div class="max max--xsml text-center shim-pb2">
-          <h1 class="shim-mb1">Talent for every<br>possible outcome</h1>
+          <h1 class="shim-mb1">Talent for every
+            <br>possible outcome
+          </h1>
           <h3 class="shim-mb2">Further details about this amazing campaign.</h3>
           <a
             class="btn btn--inverted"
-            href=""><span class="push-icon">Call to action <svg
-              width="15px"
-              height="15px"
-              focusable="false"
-              role="presentation"
-              class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+            href>
+            <span class="push-icon">Call to action
+              <svg
+                width="15px"
+                height="15px"
+                focusable="false"
+                role="presentation"
+                class="push-icon__icon"
+              >
+                <use xlink:href="#icon-chevron-right"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-1/Level1HomeCampaignOverlay25.vue
+++ b/components/page/header/stories/level-1/Level1HomeCampaignOverlay25.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header__darken--o25 page-header--campaign"
-    style="background-image: url(https://placeimg.com/990/530/arch/1)">
+    style="background-image: url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header page-header--l1">
       <div class="page-header__inner max">
         <a
@@ -18,26 +19,27 @@
       </div>
       <div class="page-header--center">
         <div class="max max--xsml text-center shim-pb2">
-          <h1 class="shim-mb1">Talent for every<br>possible outcome</h1>
+          <h1 class="shim-mb1">Talent for every
+            <br>possible outcome
+          </h1>
           <h3 class="shim-mb2">Further details about this amazing campaign.</h3>
           <a
             class="btn btn--inverted"
-            href=""><span class="push-icon">Call to action <svg
-              width="15px"
-              height="15px"
-              focusable="false"
-              role="presentation"
-              class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+            href>
+            <span class="push-icon">Call to action
+              <svg
+                width="15px"
+                height="15px"
+                focusable="false"
+                role="presentation"
+                class="push-icon__icon"
+              >
+                <use xlink:href="#icon-chevron-right"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-1/Level1HomeCampaignOverlay50.vue
+++ b/components/page/header/stories/level-1/Level1HomeCampaignOverlay50.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header__darken--o50 page-header--campaign"
-    style="background-image: url(https://placeimg.com/990/530/arch/1)">
+    style="background-image: url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header page-header--l1">
       <div class="page-header__inner max">
         <a
@@ -18,26 +19,27 @@
       </div>
       <div class="page-header--center">
         <div class="max max--xsml text-center shim-pb2">
-          <h1 class="shim-mb1">Talent for every<br>possible outcome</h1>
+          <h1 class="shim-mb1">Talent for every
+            <br>possible outcome
+          </h1>
           <h3 class="shim-mb2">Further details about this amazing campaign.</h3>
           <a
             class="btn btn--inverted"
-            href=""><span class="push-icon">Call to action <svg
-              width="15px"
-              height="15px"
-              focusable="false"
-              role="presentation"
-              class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+            href>
+            <span class="push-icon">Call to action
+              <svg
+                width="15px"
+                height="15px"
+                focusable="false"
+                role="presentation"
+                class="push-icon__icon"
+              >
+                <use xlink:href="#icon-chevron-right"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-1/Level1HomeCampaignOverlay75.vue
+++ b/components/page/header/stories/level-1/Level1HomeCampaignOverlay75.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header__darken--o75 page-header--campaign"
-    style="background-image: url(https://placeimg.com/990/530/arch/1)">
+    style="background-image: url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header page-header--l1">
       <div class="page-header__inner max">
         <a
@@ -18,26 +19,27 @@
       </div>
       <div class="page-header--center">
         <div class="max max--xsml text-center shim-pb2">
-          <h1 class="shim-mb1">Talent for every<br>possible outcome</h1>
+          <h1 class="shim-mb1">Talent for every
+            <br>possible outcome
+          </h1>
           <h3 class="shim-mb2">Further details about this amazing campaign.</h3>
           <a
             class="btn btn--inverted"
-            href=""><span class="push-icon">Call to action <svg
-              width="15px"
-              height="15px"
-              focusable="false"
-              role="presentation"
-              class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+            href>
+            <span class="push-icon">Call to action
+              <svg
+                width="15px"
+                height="15px"
+                focusable="false"
+                role="presentation"
+                class="push-icon__icon"
+              >
+                <use xlink:href="#icon-chevron-right"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-2/Level2CampaignOverlay50.vue
+++ b/components/page/header/stories/level-2/Level2CampaignOverlay50.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="page-header__darken--o50"
-    style="background-image: url(https://placeimg.com/990/530/arch/1)">
+    style="background-image: url(https://placeimg.com/990/530/arch/1)"
+  >
     <header class="page-header page-header--l2">
       <div class="page-header__inner max">
         <a
@@ -18,26 +19,27 @@
       </div>
       <div class="page-header--center">
         <div class="max max--xsml text-center shim-pb2">
-          <h1 class="shim-mb1">Talent for every<br>possible outcome</h1>
+          <h1 class="shim-mb1">Talent for every
+            <br>possible outcome
+          </h1>
           <h3 class="shim-mb2">Further details about this amazing campaign.</h3>
           <a
             class="btn btn--inverted"
-            href=""><span class="push-icon">Call to action <svg
-              width="15px"
-              height="15px"
-              focusable="false"
-              role="presentation"
-              class="push-icon__icon"><use xlink:href="#icon-chevron-right" /></svg></span></a>
+            href>
+            <span class="push-icon">Call to action
+              <svg
+                width="15px"
+                height="15px"
+                focusable="false"
+                role="presentation"
+                class="push-icon__icon"
+              >
+                <use xlink:href="#icon-chevron-right"/>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
     </header>
   </div>
 </template>
-
-<script>
-import CardPathfinder from '../../../../cards/CardPathfinder.vue';
-
-export default {
-  components: { CardPathfinder },
-};
-</script>

--- a/components/page/header/stories/level-2/Level2Default.vue
+++ b/components/page/header/stories/level-2/Level2Default.vue
@@ -2,8 +2,7 @@
   <PageHeader
     :level="2"
     title="Strategy and governance"
-    img="https://placeimg.com/990/530/arch/1"
-  />
+    img="https://placeimg.com/990/530/arch/1"/>
 </template>
 
 <script>
@@ -11,5 +10,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-2/Level2DualEntity.vue
+++ b/components/page/header/stories/level-2/Level2DualEntity.vue
@@ -13,5 +13,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-2/Level2Entity.vue
+++ b/components/page/header/stories/level-2/Level2Entity.vue
@@ -12,5 +12,6 @@ import PageHeader from '../../PageHeader.vue';
 
 export default {
   components: { PageHeader },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/page/header/stories/level-3/Level3Alt.vue
+++ b/components/page/header/stories/level-3/Level3Alt.vue
@@ -1,5 +1,5 @@
 <template>
-  <PageHeaderMin :image="`url('${reconBG}')` " />
+  <PageHeaderMin :image="`url('${reconBG}')` "/>
 </template>
 
 <script>
@@ -7,6 +7,7 @@ import PageHeaderMin from '../../PageHeaderMin.vue';
 import reconBG from '../../../../shared/reconciliation-banner-background.png';
 export default {
   components: { PageHeaderMin },
+  readme: { source: true, html: true },
   data() {
     return {
       reconBG,

--- a/components/page/header/stories/level-3/Level3Default.vue
+++ b/components/page/header/stories/level-3/Level3Default.vue
@@ -1,5 +1,5 @@
 <template>
-  <PageHeaderMin />
+  <PageHeaderMin/>
 </template>
 
 <script>
@@ -7,5 +7,6 @@ import PageHeaderMin from '../../PageHeaderMin.vue';
 
 export default {
   components: { PageHeaderMin },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/pathfinder/Pathfinder.vue
+++ b/components/pathfinder/Pathfinder.vue
@@ -1,16 +1,17 @@
 <template>
   <section
     :style="{ backgroundImage: `url(${image})` }"
-    class="section section--image bg-inverted-dark">
+    class="section section--image bg-inverted-dark"
+  >
     <div class="section--image-mask"/>
     <div class="section__inner">
       <div class="listing listing--three listing--center">
         <ListItem
           v-for="box in boxes.split(',')"
           :key="box">
-          <CardPathfinder :title="box">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+          <CardPathfinder
+            :title="box"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
       </div>
     </div>

--- a/components/pathfinder/stories/Focus/Story1.vue
+++ b/components/pathfinder/stories/Focus/Story1.vue
@@ -1,23 +1,24 @@
 <template>
   <section
     :style="{ backgroundImage: `url(${crest})` }"
-    class="section section--image bg-inverted-dark">
+    class="section section--image bg-inverted-dark"
+  >
     <div class="section__inner">
       <div class="grid grid--3col grid--center">
         <ListItem>
-          <CardPathfinder title="Engagement outcomes">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+          <CardPathfinder
+            title="Engagement outcomes"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
-          <CardPathfinder title="A longer title goes here">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+          <CardPathfinder
+            title="A longer title goes here"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
-          <CardPathfinder title="World class research">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+          <CardPathfinder
+            title="World class research"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
       </div>
     </div>
@@ -30,6 +31,7 @@ import CardPathfinder from '../../../cards/CardPathfinder.vue';
 
 export default {
   components: { CardPathfinder },
+  readme: { source: true, html: true },
   data: () => ({ crest }),
 };
 </script>

--- a/components/pathfinder/stories/Focus/Story2.vue
+++ b/components/pathfinder/stories/Focus/Story2.vue
@@ -1,29 +1,27 @@
 <template>
   <section
     :style="{ backgroundImage: `url(${crest})` }"
-    class="section section--image bg-inverted-dark">
+    class="section section--image bg-inverted-dark"
+  >
     <div class="section__inner">
       <div class="grid grid--3col grid--center">
         <ListItem>
           <CardPathfinder
             compact
-            title="Engagement">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="Engagement"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
           <CardPathfinder
             compact
-            title="Something">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="Something"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
           <CardPathfinder
             compact
-            title="World class ">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="World class "
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
       </div>
     </div>
@@ -36,6 +34,7 @@ import CardPathfinder from '../../../cards/CardPathfinder.vue';
 
 export default {
   components: { CardPathfinder },
+  readme: { source: true, html: true },
   data: () => ({ crest }),
 };
 </script>

--- a/components/pathfinder/stories/Focus/Story3.vue
+++ b/components/pathfinder/stories/Focus/Story3.vue
@@ -1,29 +1,27 @@
 <template>
   <section
     :style="{ backgroundImage: 'url(https://about-us-unimelb.netlify.com/images/our-history/leaves.jpg)' }"
-    class="section section--image section--image-mask bg-inverted">
+    class="section section--image section--image-mask bg-inverted"
+  >
     <div class="section__inner">
       <div class="grid grid--3col grid--center">
         <ListItem>
           <CardPathfinder
             compact
-            title="Engagement">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="Engagement"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
           <CardPathfinder
             compact
-            title="Something">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="Something"
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
         <ListItem>
           <CardPathfinder
             compact
-            title="World class ">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.
-          </CardPathfinder>
+            title="World class "
+          >Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus facilis libero in, ipsam quidem cupiditate! Dignissimos pariatur, repellendus dolore nemo saepe, et dolor maxime, enim rem sapiente debitis minima blanditiis.</CardPathfinder>
         </ListItem>
       </div>
     </div>
@@ -35,5 +33,6 @@ import CardPathfinder from '../../../cards/CardPathfinder.vue';
 
 export default {
   components: { CardPathfinder },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/pathfinder/stories/Image/Story1.vue
+++ b/components/pathfinder/stories/Image/Story1.vue
@@ -4,37 +4,32 @@
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/300x400"
-          title="Growing esteem" >
-          Find out about our strategic journey and where we're headed.
-        </CardImage>
+          title="Growing esteem"
+        >Find out about our strategic journey and where we're headed.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/600x200"
-          title="Melbourne model" >
-          Check out how our degrees are structured to give our students flexibility and focus.
-        </CardImage>
+          title="Melbourne model"
+        >Check out how our degrees are structured to give our students flexibility and focus.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/300x200"
-          title="Our structure">
-          this is a test of the content
-        </CardImage>
+          title="Our structure"
+        >this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/550x200"
-          title="Governance">
-          this is a test of the content
-        </CardImage>
+          title="Governance"
+        >this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/400x200"
-          title="Annual reports" >
-          See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.
-        </CardImage>
+          title="Annual reports"
+        >See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.</CardImage>
       </ListItem>
     </div>
   </SectionWrap>
@@ -45,6 +40,6 @@ import CardImage from '../../../cards/CardImage.vue';
 
 export default {
   components: { CardImage },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Image/Story2.vue
+++ b/components/pathfinder/stories/Image/Story2.vue
@@ -4,37 +4,30 @@
       <ListItem>
         <CardImage
           compact
-          title="Growing esteem" >
-          Find out about our strategic journey and where we're headed.
-        </CardImage>
+          title="Growing esteem"
+        >Find out about our strategic journey and where we're headed.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Melbourne model" >
-          Check out how our degrees are structured to give our students flexibility and focus.
-        </CardImage>
+          title="Melbourne model"
+        >Check out how our degrees are structured to give our students flexibility and focus.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Our structure">
-          this is a test of the content
-        </CardImage>
+          title="Our structure">this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Governance">
-          this is a test of the content
-        </CardImage>
+          title="Governance">this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Annual reports" >
-          See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.
-        </CardImage>
+          title="Annual reports"
+        >See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.</CardImage>
       </ListItem>
     </div>
   </SectionWrap>
@@ -45,6 +38,6 @@ import CardImage from '../../../cards/CardImage.vue';
 
 export default {
   components: { CardImage },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Image/Story3.vue
+++ b/components/pathfinder/stories/Image/Story3.vue
@@ -4,37 +4,32 @@
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/300x400"
-          title="Growing esteem" >
-          Find out about our strategic journey and where we're headed.
-        </CardImage>
+          title="Growing esteem"
+        >Find out about our strategic journey and where we're headed.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/600x200"
-          title="Melbourne model" >
-          Check out how our degrees are structured to give our students flexibility and focus.
-        </CardImage>
+          title="Melbourne model"
+        >Check out how our degrees are structured to give our students flexibility and focus.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/300x200"
-          title="Our structure">
-          this is a test of the content
-        </CardImage>
+          title="Our structure"
+        >this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/550x200"
-          title="Governance">
-          this is a test of the content
-        </CardImage>
+          title="Governance"
+        >this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           thumb="https://via.placeholder.com/400x200"
-          title="Annual reports" >
-          See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.
-        </CardImage>
+          title="Annual reports"
+        >See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.</CardImage>
       </ListItem>
     </div>
   </SectionWrap>
@@ -45,6 +40,6 @@ import CardImage from '../../../cards/CardImage.vue';
 
 export default {
   components: { CardImage },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Image/Story4.vue
+++ b/components/pathfinder/stories/Image/Story4.vue
@@ -4,37 +4,30 @@
       <ListItem>
         <CardImage
           compact
-          title="Growing esteem" >
-          Find out about our strategic journey and where we're headed.
-        </CardImage>
+          title="Growing esteem"
+        >Find out about our strategic journey and where we're headed.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Melbourne model" >
-          Check out how our degrees are structured to give our students flexibility and focus.
-        </CardImage>
+          title="Melbourne model"
+        >Check out how our degrees are structured to give our students flexibility and focus.</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Our structure">
-          this is a test of the content
-        </CardImage>
+          title="Our structure">this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Governance">
-          this is a test of the content
-        </CardImage>
+          title="Governance">this is a test of the content</CardImage>
       </ListItem>
       <ListItem>
         <CardImage
           compact
-          title="Annual reports" >
-          See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.
-        </CardImage>
+          title="Annual reports"
+        >See our governance details, including organisation and governance structures, regulatory framework, compliance obligations and risk management.</CardImage>
       </ListItem>
     </div>
   </SectionWrap>
@@ -45,6 +38,6 @@ import CardImage from '../../../cards/CardImage.vue';
 
 export default {
   components: { CardImage },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Link/Story1.vue
+++ b/components/pathfinder/stories/Link/Story1.vue
@@ -1,15 +1,21 @@
 <template>
   <SectionWrap>
     <div class="grid grid--4col grid--center">
-      <ListItem><card-link
-        inverted
-        title="Ranking and Statistics" /></ListItem>
-      <ListItem><card-link
-        inverted
-        title="Study" /></ListItem>
-      <ListItem><card-link
-        inverted
-        title="Facts and figures" /></ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Ranking and Statistics"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Study"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Facts and figures"/>
+      </ListItem>
     </div>
   </SectionWrap>
 </template>
@@ -19,6 +25,6 @@ import CardLink from '../../../cards/CardLink.vue';
 
 export default {
   components: { CardLink },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Link/Story2.vue
+++ b/components/pathfinder/stories/Link/Story2.vue
@@ -1,18 +1,26 @@
 <template>
   <SectionWrap>
     <div class="grid grid--4col grid--center">
-      <ListItem><card-link
-        inverted
-        title="Test 1"/></ListItem>
-      <ListItem><card-link
-        inverted
-        title="Test 2"/></ListItem>
-      <ListItem><card-link
-        inverted
-        title="This is a Longer title over two lines"/></ListItem>
-      <ListItem><card-link
-        inverted
-        title="Ranking and Statistics"/></ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Test 1"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Test 2"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="This is a Longer title over two lines"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Ranking and Statistics"/>
+      </ListItem>
     </div>
   </SectionWrap>
 </template>
@@ -22,6 +30,6 @@ import CardLink from '../../../cards/CardLink.vue';
 
 export default {
   components: { CardLink },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Link/Story3.vue
+++ b/components/pathfinder/stories/Link/Story3.vue
@@ -1,15 +1,22 @@
 <template>
   <SectionWrap>
     <div class="grid grid--4col grid--center">
-      <ListItem><card-link
-        inverted
-        title="Test 1"/></ListItem>
-      <ListItem><card-link
-        inverted
-        title="This is an even Longer title that totally goes over three lines"/></ListItem>
-      <ListItem><card-link
-        inverted
-        title="This is a Longer title over two lines"/></ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="Test 1"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="This is an even Longer title that totally goes over three lines"
+        />
+      </ListItem>
+      <ListItem>
+        <card-link
+          inverted
+          title="This is a Longer title over two lines"/>
+      </ListItem>
     </div>
   </SectionWrap>
 </template>
@@ -19,6 +26,6 @@ import CardLink from '../../../cards/CardLink.vue';
 
 export default {
   components: { CardLink },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/pathfinder/stories/Link/Story4.vue
+++ b/components/pathfinder/stories/Link/Story4.vue
@@ -1,22 +1,30 @@
 <template>
   <SectionWrap>
     <div class="grid grid--4col grid--center">
-      <ListItem><card-link
-        :thumb="false"
-        inverted
-        title="Test 1"/></ListItem>
-      <ListItem><card-link
-        :thumb="false"
-        inverted
-        title="Test 2"/></ListItem>
-      <ListItem><card-link
-        :thumb="false"
-        inverted
-        title="This is a Longer title over two lines"/></ListItem>
-      <ListItem><card-link
-        :thumb="false"
-        inverted
-        title="Ranking and Statistics"/></ListItem>
+      <ListItem>
+        <card-link
+          :thumb="false"
+          inverted
+          title="Test 1"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          :thumb="false"
+          inverted
+          title="Test 2"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          :thumb="false"
+          inverted
+          title="This is a Longer title over two lines"/>
+      </ListItem>
+      <ListItem>
+        <card-link
+          :thumb="false"
+          inverted
+          title="Ranking and Statistics"/>
+      </ListItem>
     </div>
   </SectionWrap>
 </template>
@@ -26,6 +34,6 @@ import CardLink from '../../../cards/CardLink.vue';
 
 export default {
   components: { CardLink },
+  readme: { source: true, html: true },
 };
-
 </script>

--- a/components/section/stories/Crest/Story1.vue
+++ b/components/section/stories/Crest/Story1.vue
@@ -2,9 +2,18 @@
   <SectionWrap
     class="text-center"
     bg-color="inverted"
-    bg-image="https://cms.unimelb.edu.au/__data/assets/image/0005/2353784/UoM-soft-3.png">
+    bg-image="https://cms.unimelb.edu.au/__data/assets/image/0005/2353784/UoM-soft-3.png"
+  >
     <h3 class="heading-section">Our Vision</h3>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Possimus consequuntur cumque adipisci illum eveniet, et, obcaecati cum officia vero laborum culpa est nobis accusantium debitis iusto quis voluptate repellat distinctio.</p>
-    <div><button class="btn btn--inverted btn--wide">Call to action</button></div>
+    <div>
+      <button class="btn btn--inverted btn--wide">Call to action</button>
+    </div>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Crest/Story2.vue
+++ b/components/section/stories/Crest/Story2.vue
@@ -1,5 +1,5 @@
 <template>
-  <SectionDivider title="Some Heading" />
+  <SectionDivider title="Some Heading"/>
 </template>
 
 <script>
@@ -8,5 +8,6 @@ export default {
   components: {
     SectionDivider,
   },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Crest/Story3.vue
+++ b/components/section/stories/Crest/Story3.vue
@@ -1,7 +1,7 @@
 <template>
   <SectionDivider
     title="Some Heading"
-    subtitle="Based on statistics" />
+    subtitle="Based on statistics"/>
 </template>
 
 <script>
@@ -10,5 +10,6 @@ export default {
   components: {
     SectionDivider,
   },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Focus/Story1.vue
+++ b/components/section/stories/Focus/Story1.vue
@@ -1,11 +1,11 @@
 <template>
   <SectionWrap
     small
-    bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+    bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+  >
     <CardFocusBox
       class="card--image-focus--col-brand"
-      title="Learning and teaching"
-    >
+      title="Learning and teaching">
       <h2>Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Enim accusamus dolorum labore, odit libero maxime nam inventore neque ratione optio quos sapiente atque ex fuga blanditiis alias, ducimus ut? Voluptatibus.</p>
     </CardFocusBox>
@@ -17,5 +17,6 @@ import CardFocusBox from '../../../cards/CardFocusBox.vue';
 
 export default {
   components: { CardFocusBox },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Focus/Story2.vue
+++ b/components/section/stories/Focus/Story2.vue
@@ -1,9 +1,10 @@
 <template>
-  <SectionWrap bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+  <SectionWrap
+    bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+  >
     <CardFocusBox
       class="card--image-focus--col-brand"
-      title="Learning and teaching"
-    >
+      title="Learning and teaching">
       <h2 class="text-left">Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Enim accusamus dolorum labore, odit libero maxime nam inventore neque ratione optio quos sapiente atque ex fuga blanditiis alias, ducimus ut? Voluptatibus.</p>
     </CardFocusBox>
@@ -15,5 +16,6 @@ import CardFocusBox from '../../../cards/CardFocusBox.vue';
 
 export default {
   components: { CardFocusBox },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Focus/Story3.vue
+++ b/components/section/stories/Focus/Story3.vue
@@ -2,11 +2,11 @@
   <SectionWrap
     progressive
     small
-    bg-image="https://images.unsplash.com/photo-1495855720902-bb60e936d7ca?dpr=1&auto=compress,format&fit=crop&w=1498&h=&q=80&cs=tinysrgb&crop=">
+    bg-image="https://images.unsplash.com/photo-1495855720902-bb60e936d7ca?dpr=1&auto=compress,format&fit=crop&w=1498&h=&q=80&cs=tinysrgb&crop="
+  >
     <CardFocusBox
       class="card--image-focus--col-brand"
-      title="Learning and teaching"
-    >
+      title="Learning and teaching">
       <h2 class="text-left">Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Enim accusamus dolorum labore, odit libero maxime nam inventore neque ratione optio quos sapiente atque ex fuga blanditiis alias, ducimus ut? Voluptatibus.</p>
     </CardFocusBox>
@@ -18,5 +18,6 @@ import CardFocusBox from '../../../cards/CardFocusBox.vue';
 
 export default {
   components: { CardFocusBox },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Focus/Story4.vue
+++ b/components/section/stories/Focus/Story4.vue
@@ -2,7 +2,8 @@
   <main>
     <SectionWrap
       small
-      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+    >
       <CardFocusBox
         element="div"
         compact
@@ -15,7 +16,8 @@
     </SectionWrap>
     <SectionWrap
       small
-      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+    >
       <CardFocusBox
         element="div"
         compact
@@ -29,7 +31,8 @@
     </SectionWrap>
     <SectionWrap
       small
-      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+    >
       <CardFocusBox
         element="div"
         compact
@@ -43,7 +46,8 @@
     </SectionWrap>
     <SectionWrap
       small
-      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+    >
       <CardFocusBox
         element="div"
         compact
@@ -57,7 +61,8 @@
     </SectionWrap>
     <SectionWrap
       small
-      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+    >
       <CardFocusBox
         element="div"
         compact
@@ -77,5 +82,6 @@ import CardFocusBox from '../../../cards/CardFocusBox.vue';
 
 export default {
   components: { CardFocusBox },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Focus/Story5.vue
+++ b/components/section/stories/Focus/Story5.vue
@@ -1,18 +1,17 @@
 <template>
   <SectionWrap
     small
-    bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop=">
+    bg-image="https://images.unsplash.com/photo-1505639594395-22cc30113a4e?dpr=1&auto=compress,format&fit=crop&w=1200&h=&q=80&cs=tinysrgb&crop="
+  >
     <CardFocusBox
       class="card--image-focus--col-brand"
-      title="Learning and teaching"
-    >
+      title="Learning and teaching">
       <h2>Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Enim accusamus dolorum labore, odit libero maxime nam inventore neque ratione optio quos sapiente atque ex fuga blanditiis alias, ducimus ut? Voluptatibus.</p>
       <a
         href="https://www.unimelb.edu.au"
-        class="btn btn--icon btn--icon--chevron-right">
-        Call to Action
-      </a>
+        class="btn btn--icon btn--icon--chevron-right"
+      >Call to Action</a>
     </CardFocusBox>
   </SectionWrap>
 </template>
@@ -22,5 +21,6 @@ import CardFocusBox from '../../../cards/CardFocusBox.vue';
 
 export default {
   components: { CardFocusBox },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/Section/Story1.vue
+++ b/components/section/stories/Section/Story1.vue
@@ -1,6 +1,14 @@
 <template>
   <SectionWrap bg-color="white">
     <h2>Section Heading</h2>
-    <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+    <p>Lorem ipsum dolor sit amet,
+      <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+    </p>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Section/Story2.vue
+++ b/components/section/stories/Section/Story2.vue
@@ -1,6 +1,14 @@
 <template>
   <SectionWrap bg-color="inverted">
     <h2>Section Heading</h2>
-    <p>Lorem ipsum dolor sit amet, <a href="g">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+    <p>Lorem ipsum dolor sit amet,
+      <a href="g">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+    </p>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Section/Story3.vue
+++ b/components/section/stories/Section/Story3.vue
@@ -1,6 +1,14 @@
 <template>
   <SectionWrap bg-color="alt">
     <h2>Section Heading</h2>
-    <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+    <p>Lorem ipsum dolor sit amet,
+      <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+    </p>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Section/Story4.vue
+++ b/components/section/stories/Section/Story4.vue
@@ -3,6 +3,14 @@
     small
     bg-color="white">
     <h2>Section Heading</h2>
-    <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+    <p>Lorem ipsum dolor sit amet,
+      <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+    </p>
   </SectionWrap>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Section/Story5.vue
+++ b/components/section/stories/Section/Story5.vue
@@ -4,13 +4,23 @@
       short
       bg-color="white">
       <h2>Section Heading</h2>
-      <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+      <p>Lorem ipsum dolor sit amet,
+        <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+      </p>
     </SectionWrap>
     <SectionWrap
       short
       bg-color="alt">
-      <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+      <p>Lorem ipsum dolor sit amet,
+        <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+      </p>
       <p>Ut rem expedita dolore cupiditate laudantium blanditiis voluptatem laborum impedit.</p>
     </SectionWrap>
   </main>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/Section/Story6.vue
+++ b/components/section/stories/Section/Story6.vue
@@ -4,12 +4,22 @@
       nopad
       bg-color="white">
       <h2>Section Heading</h2>
-      <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+      <p>Lorem ipsum dolor sit amet,
+        <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+      </p>
     </SectionWrap>
     <SectionWrap
       nopad
       bg-color="alt">
-      <p>Lorem ipsum dolor sit amet, <a href="">consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.</p>
+      <p>Lorem ipsum dolor sit amet,
+        <a href>consectetur adipisicing</a> elit. Adipisci fugiat odio cupiditate ad nisi exercitationem incidunt reprehenderit nemo repellendus ea, eveniet, nostrum sunt earum similique quaerat maxime, iure recusandae inventore.
+      </p>
     </SectionWrap>
   </main>
 </template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/SectionTwo/Story1.vue
+++ b/components/section/stories/SectionTwo/Story1.vue
@@ -17,7 +17,7 @@
       <FigureWrap>
         <img
           src="https://dummyimage.com/300x200.jpg"
-          alt="">
+          alt="test">
       </FigureWrap>
       <p>Qui rerum laudantium quis hic tempora. Quia suscipit placeat est illo omnis nemo fuga. Nobis suscipit sint odit quidem sit et sed deleniti.</p>
     </div>
@@ -29,5 +29,6 @@ import SectionTwoCol from '../../SectionTwoCol.vue';
 import FigureWrap from '../../../figure/FigureWrap.vue';
 export default {
   components: { SectionTwoCol, FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SectionTwo/Story1.vue
+++ b/components/section/stories/SectionTwo/Story1.vue
@@ -17,7 +17,7 @@
       <FigureWrap>
         <img
           src="https://dummyimage.com/300x200.jpg"
-          alt="test">
+          alt="alt text goes here">
       </FigureWrap>
       <p>Qui rerum laudantium quis hic tempora. Quia suscipit placeat est illo omnis nemo fuga. Nobis suscipit sint odit quidem sit et sed deleniti.</p>
     </div>

--- a/components/section/stories/SectionTwo/Story2.vue
+++ b/components/section/stories/SectionTwo/Story2.vue
@@ -3,14 +3,13 @@
     <div slot="main">
       <h3 class="heading-section">Doloribus in mollitia.</h3>
       <p>Qui rem enim alias accusantium ut nostrum et iste. A quo voluptatem in culpa repudiandae facere. Veritatis magnam omnis distinctio ea modi. Ipsam aperiam corporis dolorum.</p>
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
     </div>
     <div slot="side">
       <FigureWrap>
         <img
           src="https://dummyimage.com/300x200.jpg"
-          alt="">
+          alt="test">
       </FigureWrap>
     </div>
   </SectionTwoCol>
@@ -21,5 +20,6 @@ import SectionTwoCol from '../../SectionTwoCol.vue';
 import FigureWrap from '../../../figure/FigureWrap.vue';
 export default {
   components: { SectionTwoCol, FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SectionTwo/Story3.vue
+++ b/components/section/stories/SectionTwo/Story3.vue
@@ -11,7 +11,7 @@
       <FigureWrap>
         <img
           src="https://dummyimage.com/300x200.jpg"
-          alt>
+          alt="alt text goes here">
       </FigureWrap>
     </div>
   </SectionTwoCol>

--- a/components/section/stories/SectionTwo/Story3.vue
+++ b/components/section/stories/SectionTwo/Story3.vue
@@ -5,14 +5,13 @@
     <div slot="main">
       <h3 class="heading-section">Doloribus in mollitia.</h3>
       <p>Qui rem enim alias accusantium ut nostrum et iste. A quo voluptatem in culpa repudiandae facere. Veritatis magnam omnis distinctio ea modi. Ipsam aperiam corporis dolorum.</p>
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
     </div>
     <div slot="side">
       <FigureWrap>
         <img
           src="https://dummyimage.com/300x200.jpg"
-          alt="">
+          alt>
       </FigureWrap>
     </div>
   </SectionTwoCol>
@@ -23,5 +22,6 @@ import SectionTwoCol from '../../SectionTwoCol.vue';
 import FigureWrap from '../../../figure/FigureWrap.vue';
 export default {
   components: { SectionTwoCol, FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SectionTwo/Story4.vue
+++ b/components/section/stories/SectionTwo/Story4.vue
@@ -3,12 +3,11 @@
     <div slot="main">
       <h3 class="heading-section">Doloribus in mollitia.</h3>
       <p>Qui rem enim alias accusantium ut nostrum et iste. A quo voluptatem in culpa repudiandae facere. Veritatis magnam omnis distinctio ea modi. Ipsam aperiam corporis dolorum.</p>
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi ipsa neque nemo, nam veritatis quasi ea perspiciatis laudantium aliquid alias velit sed quam tenetur dolorum, nihil quo pariatur cum commodi?</p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut numquam ex perspiciatis harum amet laudantium sint error vitae exercitationem sapiente a nisi debitis ipsum sed voluptates natus, esse aut modi.
     </div>
     <div slot="side">
       <h3>nemo sed quo</h3>
-      <p> Sapiente qui porro facere vel neque molestiae accusantium assumenda ut. </p>
+      <p>Sapiente qui porro facere vel neque molestiae accusantium assumenda ut.</p>
     </div>
   </SectionTwoCol>
 </template>
@@ -18,5 +17,6 @@ import SectionTwoCol from '../../SectionTwoCol.vue';
 import FigureWrap from '../../../figure/FigureWrap.vue';
 export default {
   components: { SectionTwoCol, FigureWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SplitSection/Story2.vue
+++ b/components/section/stories/SplitSection/Story2.vue
@@ -2,7 +2,8 @@
   <main class="bg-white">
     <SplitSection
       image-right
-      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop="
+    >
       <h3 class="heading-section">This is a header</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt error architecto provident beatae autem optio, et vel repellendus assumenda aliquid, non cumque esse aliquam neque earum voluptatibus, perferendis maiores obcaecati.</p>
     </SplitSection>
@@ -14,5 +15,6 @@ import SplitSection from '../../SplitSection.vue';
 
 export default {
   components: { SplitSection },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SplitSection/Story3.vue
+++ b/components/section/stories/SplitSection/Story3.vue
@@ -4,7 +4,8 @@
       image-left
       quote="University of Melbourne has provided opportunities i could never imagine. This is a ridiculously long quote because people like to be especially verbose. eos minima at"
       cite="Rebecca Lam, Molecular Biology"
-      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop="
+    >
       <h3 class="heading-section">This is a header</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt error architecto provident beatae autem optio, et vel repellendus assumenda aliquid, non cumque esse aliquam neque earum voluptatibus, perferendis maiores obcaecati.</p>
     </SplitSection>
@@ -16,5 +17,6 @@ import SplitSection from '../../SplitSection.vue';
 
 export default {
   components: { SplitSection },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/section/stories/SplitSection/Story4.vue
+++ b/components/section/stories/SplitSection/Story4.vue
@@ -4,7 +4,8 @@
       image-right
       quote="University of Melbourne has provided opportunities i could never imagine"
       cite="Rebecca Lam, Molecular Biology"
-      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop=">
+      bg-image="https://images.unsplash.com/photo-1428509774491-cfac96e12253?dpr=1&auto=compress,format&fit=crop&w=600&h=&q=80&cs=tinysrgb&crop="
+    >
       <h3 class="heading-section">This is a header</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt error architecto provident beatae autem optio, et vel repellendus assumenda aliquid, non cumque esse aliquam neque earum voluptatibus, perferendis maiores obcaecati.</p>
     </SplitSection>
@@ -16,5 +17,6 @@ import SplitSection from '../../SplitSection.vue';
 
 export default {
   components: { SplitSection },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/side-panel/stories/Left/Story1.vue
+++ b/components/side-panel/stories/Left/Story1.vue
@@ -3,9 +3,9 @@
     <SidePanel
       class="layout__pre bg-light-blue"
       title="Navigation">
-      <SidePanelNavItem target="#section1"> Section 1</SidePanelNavItem>
-      <SidePanelNavItem target="#section2"> Section 2</SidePanelNavItem>
-      <SidePanelNavItem target="#section3"> Section 3</SidePanelNavItem>
+      <SidePanelNavItem target="#section1">Section 1</SidePanelNavItem>
+      <SidePanelNavItem target="#section2">Section 2</SidePanelNavItem>
+      <SidePanelNavItem target="#section3">Section 3</SidePanelNavItem>
     </SidePanel>
     <SectionWrap
       id="section1"
@@ -15,14 +15,10 @@
     </SectionWrap>
     <SectionWrap
       id="section2"
-      class="bg-alt">
-      test content
-    </SectionWrap>
+      class="bg-alt">test content</SectionWrap>
     <SectionWrap
       id="section3"
-      class="bg-white">
-      test content
-    </SectionWrap>
+      class="bg-white">test content</SectionWrap>
   </main>
 </template>
 
@@ -34,5 +30,6 @@ import PageDecorator from '../../../../.storybook/decorators/PageDecorator.vue';
 export default {
   components: { SidePanel, SidePanelNavItem },
   decorator: PageDecorator,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/side-panel/stories/Left/Story2.vue
+++ b/components/side-panel/stories/Left/Story2.vue
@@ -1,9 +1,9 @@
 <template>
   <main class="layout layout--left bg-light-blue">
     <SidePanel class="layout__pre bg-light-blue">
-      <SidePanelNavItem target="#section1"> Section 1</SidePanelNavItem>
-      <SidePanelNavItem target="#section2"> Section 2</SidePanelNavItem>
-      <SidePanelNavItem target="#section3"> Section 3</SidePanelNavItem>
+      <SidePanelNavItem target="#section1">Section 1</SidePanelNavItem>
+      <SidePanelNavItem target="#section2">Section 2</SidePanelNavItem>
+      <SidePanelNavItem target="#section3">Section 3</SidePanelNavItem>
     </SidePanel>
     <div
       id="section1"
@@ -13,14 +13,10 @@
     </div>
     <SectionWrap
       id="section2"
-      class="bg-alt">
-      test content
-    </SectionWrap>
+      class="bg-alt">test content</SectionWrap>
     <SectionWrap
       id="section3"
-      class="bg-white">
-      test content
-    </SectionWrap>
+      class="bg-white">test content</SectionWrap>
   </main>
 </template>
 
@@ -32,5 +28,6 @@ import PageDecorator from '../../../../.storybook/decorators/PageDecorator.vue';
 export default {
   components: { SidePanel, SidePanelNavItem },
   decorator: PageDecorator,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/side-panel/stories/Right/Story1.vue
+++ b/components/side-panel/stories/Right/Story1.vue
@@ -1,9 +1,9 @@
 <template>
   <main class="layout layout--right clearfix bg-light-blue">
     <SidePanel class="layout__post bg-light-blue">
-      <SidePanelNavItem target="#section1"> Section 1</SidePanelNavItem>
-      <SidePanelNavItem target="#section2"> Section 2</SidePanelNavItem>
-      <SidePanelNavItem target="#section3"> Section 3</SidePanelNavItem>
+      <SidePanelNavItem target="#section1">Section 1</SidePanelNavItem>
+      <SidePanelNavItem target="#section2">Section 2</SidePanelNavItem>
+      <SidePanelNavItem target="#section3">Section 3</SidePanelNavItem>
     </SidePanel>
     <div class="layout__main">
       <section-wrap
@@ -13,14 +13,10 @@
       </section-wrap>
       <section-wrap
         id="section2"
-        class="bg-alt">
-        test content
-      </section-wrap>
+        class="bg-alt">test content</section-wrap>
       <section-wrap
         id="section3"
-        class="bg-white">
-        test content
-      </section-wrap>
+        class="bg-white">test content</section-wrap>
     </div>
   </main>
 </template>
@@ -33,5 +29,6 @@ import PageDecorator from '../../../../.storybook/decorators/PageDecorator.vue';
 export default {
   components: { SidePanel, SidePanelNavItem },
   decorator: PageDecorator,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/side-panel/stories/Right/Story2.vue
+++ b/components/side-panel/stories/Right/Story2.vue
@@ -1,9 +1,9 @@
 <template>
   <main class="layout layout--right clearfix bg-light-blue">
     <SidePanel class="layout__post bg-light-blue">
-      <SidePanelNavItem target="#section1"> Section 1</SidePanelNavItem>
-      <SidePanelNavItem target="#section2"> Section 2</SidePanelNavItem>
-      <SidePanelNavItem target="#section3"> Section 3</SidePanelNavItem>
+      <SidePanelNavItem target="#section1">Section 1</SidePanelNavItem>
+      <SidePanelNavItem target="#section2">Section 2</SidePanelNavItem>
+      <SidePanelNavItem target="#section3">Section 3</SidePanelNavItem>
     </SidePanel>
     <div class="layout__main">
       <div
@@ -13,14 +13,10 @@
       </div>
       <section-wrap
         id="section2"
-        class="bg-alt">
-        test content
-      </section-wrap>
+        class="bg-alt">test content</section-wrap>
       <section-wrap
         id="section3"
-        class="bg-white">
-        test content
-      </section-wrap>
+        class="bg-white">test content</section-wrap>
     </div>
   </main>
 </template>
@@ -33,5 +29,6 @@ import PageDecorator from '../../../../.storybook/decorators/PageDecorator.vue';
 export default {
   components: { SidePanel, SidePanelNavItem },
   decorator: PageDecorator,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/social-list/stories/SocialListDefault.vue
+++ b/components/social-list/stories/SocialListDefault.vue
@@ -1,5 +1,5 @@
 <template>
-  <SocialList />
+  <SocialList/>
 </template>
 
 <script>
@@ -9,5 +9,6 @@ import PadDecorator from '../../../.storybook/decorators/PadDecorator.vue';
 export default {
   components: { SocialList },
   decorator: PadDecorator,
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/social-list/stories/SocialListInverted.vue
+++ b/components/social-list/stories/SocialListInverted.vue
@@ -1,5 +1,5 @@
 <template>
-  <SocialList :with-colors="false" />
+  <SocialList :with-colors="false"/>
 </template>
 
 <script>
@@ -10,5 +10,6 @@ export default {
   components: { SocialList },
   decorator: PadDecorator,
   decoratorProps: { class: 'bg-inverted' },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/stats/stories/StatsGroupDefault.vue
+++ b/components/stats/stories/StatsGroupDefault.vue
@@ -3,15 +3,15 @@
     <StatsItem
       :icon="icons[0]"
       number="1"
-      meta="in Australia" />
+      meta="in Australia"/>
     <StatsItem
       :icon="icons[1]"
       number="33"
-      meta="in the world" />
+      meta="in the world"/>
     <StatsItem
       :icon="icons[2]"
       number="11"
-      meta="Graduate employability worldwide" />
+      meta="Graduate employability worldwide"/>
   </StatsGroup>
 </template>
 
@@ -26,5 +26,6 @@ export default {
   data: () => ({ icons }),
   decorator: ContentBlock,
   decoratorProps: { size: 'sml' },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/stats/stories/StatsGroupInverted.vue
+++ b/components/stats/stories/StatsGroupInverted.vue
@@ -3,15 +3,15 @@
     <StatsItem
       :icon="icons[0]"
       number="1"
-      meta="in Australia" />
+      meta="in Australia"/>
     <StatsItem
       :icon="icons[1]"
       number="33"
-      meta="in the world" />
+      meta="in the world"/>
     <StatsItem
       :icon="icons[2]"
       number="11"
-      meta="Graduate employability worldwide" />
+      meta="Graduate employability worldwide"/>
   </StatsGroup>
 </template>
 
@@ -26,5 +26,6 @@ export default {
   data: () => ({ icons }),
   decorator: ContentBlock,
   decoratorProps: { bg: 'inverted' },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/stats/stories/StatsGroupInvertedSection.vue
+++ b/components/stats/stories/StatsGroupInvertedSection.vue
@@ -6,15 +6,15 @@
     <StatsItem
       :icon="icons[0]"
       number="1"
-      meta="in Australia" />
+      meta="in Australia"/>
     <StatsItem
       :icon="icons[1]"
       number="33"
-      meta="in the world" />
+      meta="in the world"/>
     <StatsItem
       :icon="icons[2]"
       number="11"
-      meta="Graduate employability worldwide" />
+      meta="Graduate employability worldwide"/>
   </StatsGroup>
 </template>
 
@@ -29,6 +29,6 @@ export default {
   data: () => ({ icons }),
   decorator: SectionWrap,
   decoratorProps: { bgColor: 'inverted' },
-  readme: { decorated: true },
+  readme: { decorated: true, source: true, html: true },
 };
 </script>

--- a/components/sublink-menu/stories/2ColText.vue
+++ b/components/sublink-menu/stories/2ColText.vue
@@ -7,24 +7,16 @@
         <SublinkMenu class="sublink-menu--pad">
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Find an expert or supervisor
-          </SublinkMenuItem>
+            link="#">Find an expert or supervisor</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Apply for graduate research
-          </SublinkMenuItem>
+            link="#something">Apply for graduate research</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Graduate research scholarships
-          </SublinkMenuItem>
+            link="#something">Graduate research scholarships</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Information for graduate researchers
-          </SublinkMenuItem>
+            link="#something">Information for graduate researchers</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
@@ -35,7 +27,9 @@
               href="#"
               class="btn-owner card card--news card--bdr card--bdr-thin">
               <p class="card__meta shim-mb0">03 Apr 2017</p>
-              <strong class="card__header shim-mt0 shim-pb1">Call for submissions for 2018 Science Gallery Melbourne exhibition</strong>
+              <strong
+                class="card__header shim-mt0 shim-pb1"
+              >Call for submissions for 2018 Science Gallery Melbourne exhibition</strong>
             </a>
           </div>
           <div class="cell cell--col-2">
@@ -43,7 +37,9 @@
               href="#"
               class="btn-owner card card--news card--bdr card--bdr-thin">
               <p class="card__meta shim-mb0">03 Apr 2017</p>
-              <strong class="card__header shim-mt0 shim-pb1">Growing girls’ interest in STEM for the workforce of the future</strong>
+              <strong
+                class="card__header shim-mt0 shim-pb1"
+              >Growing girls’ interest in STEM for the workforce of the future</strong>
             </a>
           </div>
         </div>
@@ -54,7 +50,9 @@
               href="#"
               class="btn-owner card card--news card--bdr card--bdr-thin">
               <p class="card__meta shim-mb0">03 Apr 2017</p>
-              <strong class="card__header shim-mt0 shim-pb1">Call for submissions for 2018 Science Gallery Melbourne exhibition</strong>
+              <strong
+                class="card__header shim-mt0 shim-pb1"
+              >Call for submissions for 2018 Science Gallery Melbourne exhibition</strong>
             </a>
           </div>
           <div class="cell cell--col-4">
@@ -62,7 +60,9 @@
               href="#"
               class="btn-owner card card--news card--bdr card--bdr-thin">
               <p class="card__meta shim-mb0">03 Apr 2017</p>
-              <strong class="card__header shim-mt0 shim-pb1">Growing girls’ interest in STEM for the workforce of the future</strong>
+              <strong
+                class="card__header shim-mt0 shim-pb1"
+              >Growing girls’ interest in STEM for the workforce of the future</strong>
             </a>
           </div>
         </div>
@@ -78,5 +78,6 @@ import ListingWrap from '../../listing/ListingWrap.vue';
 
 export default {
   components: { SublinkMenu, SublinkMenuItem, ListingWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/sublink-menu/stories/2Columns.vue
+++ b/components/sublink-menu/stories/2Columns.vue
@@ -7,56 +7,40 @@
         <SublinkMenu
           title="A consistent strategy"
           icon="faculty"
-          icon-color="blue">
-          a consistent look and feel in our communications
+          icon-color="blue"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A consistent tone"
           icon="library"
-          icon-color="green">
-          a consistent look and feel in our communications
+          icon-color="green"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
     </ListingWrap>
@@ -70,5 +54,6 @@ import ListingWrap from '../../listing/ListingWrap.vue';
 
 export default {
   components: { SublinkMenu, SublinkMenuItem, ListingWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/sublink-menu/stories/SublinkMenuDefault.vue
+++ b/components/sublink-menu/stories/SublinkMenuDefault.vue
@@ -5,79 +5,57 @@
         <SublinkMenu
           title="A consistent strategy"
           icon="faculty"
-          icon-color="blue">
-          a consistent look and feel in our communications
+          icon-color="blue"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A consistent tone"
           icon="library"
-          icon-color="green">
-          a consistent look and feel in our communications
+          icon-color="green"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A consistent look and feel"
           icon="location"
-          icon-color="red">
-          a consistent look and feel in our communications
+          icon-color="red"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
     </ListingWrap>
@@ -91,5 +69,6 @@ import ListingWrap from '../../listing/ListingWrap.vue';
 
 export default {
   components: { SublinkMenu, SublinkMenuItem, ListingWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/sublink-menu/stories/WithImages.vue
+++ b/components/sublink-menu/stories/WithImages.vue
@@ -6,160 +6,115 @@
       <ListItem>
         <SublinkMenu
           title="A consistent strategy"
-          img="https://picsum.photos/300/200?random&gravity=center">
-          a consistent look and feel in our communications
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A substantially longer title goes in here"
-          img="https://picsum.photos/300/200?random&gravity=center">
-          a consistent look and feel in our communications
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A substantially longer title goes in here"
-          img="https://picsum.photos/300/200?random&gravity=center">
-          a consistent look and feel in our communications
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >a consistent look and feel in our communications
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A substantially longer title goes in here"
-          img="https://picsum.photos/300/200?random&gravity=center">
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A substantially longer title goes in here"
-          img="https://picsum.photos/300/200?random&gravity=center">
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
       <ListItem>
         <SublinkMenu
           title="A substantially longer title goes in here"
-          img="https://picsum.photos/300/200?random&gravity=center">
+          img="https://picsum.photos/300/200?random&gravity=center"
+        >
           <SublinkMenuItem
             slot="menuitems"
-            link="#">
-            Our Brand Story
-          </SublinkMenuItem>
+            link="#">Our Brand Story</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
           <SublinkMenuItem
             slot="menuitems"
-            link="#something">
-            Something else
-          </SublinkMenuItem>
+            link="#something">Something else</SublinkMenuItem>
         </SublinkMenu>
       </ListItem>
     </ListingWrap>
@@ -173,5 +128,6 @@ import ListingWrap from '../../listing/ListingWrap.vue';
 
 export default {
   components: { SublinkMenu, SublinkMenuItem, ListingWrap },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/tabs/stories/TabsAlt.vue
+++ b/components/tabs/stories/TabsAlt.vue
@@ -2,7 +2,7 @@
   <Tabs alt>
     <Tab title="Use">
       <p>We write using the conventions and principles of modern Australian English.</p>
-      <p> Our style is simple and accessible, and often conversational in tone. We avoid archaic language, euphemisms and slang. Australian English is continuously evolving, so always refer to the latest edition of the Macquarie Dictionary (Macquarie Dictionary Publishers) and Style Manual: For Authors, Editors and Printers (John Wiley & Sons) for Australia’s most up-to-date spelling and grammar conventions.</p>
+      <p>Our style is simple and accessible, and often conversational in tone. We avoid archaic language, euphemisms and slang. Australian English is continuously evolving, so always refer to the latest edition of the Macquarie Dictionary (Macquarie Dictionary Publishers) and Style Manual: For Authors, Editors and Printers (John Wiley & Sons) for Australia’s most up-to-date spelling and grammar conventions.</p>
       <ButtonIcon size="xsml">I am a child component</ButtonIcon>
     </Tab>
     <Tab title="Inclusive language">

--- a/components/tabs/stories/TabsAltMin.vue
+++ b/components/tabs/stories/TabsAltMin.vue
@@ -2,11 +2,10 @@
   <div>
     <Tabs
       alt
-      min
-    >
+      min>
       <Tab title="Use">
         <p>We write using the conventions and principles of modern Australian English.</p>
-        <p> Our style is simple and accessible, and often conversational in tone. We avoid archaic language, euphemisms and slang. Australian English is continuously evolving, so always refer to the latest edition of the Macquarie Dictionary (Macquarie Dictionary Publishers) and Style Manual: For Authors, Editors and Printers (John Wiley & Sons) for Australia’s most up-to-date spelling and grammar conventions.</p>
+        <p>Our style is simple and accessible, and often conversational in tone. We avoid archaic language, euphemisms and slang. Australian English is continuously evolving, so always refer to the latest edition of the Macquarie Dictionary (Macquarie Dictionary Publishers) and Style Manual: For Authors, Editors and Printers (John Wiley & Sons) for Australia’s most up-to-date spelling and grammar conventions.</p>
         <ButtonIcon size="xsml">I am a child component</ButtonIcon>
       </Tab>
       <Tab title="Inclusive language">
@@ -18,8 +17,7 @@
     </Tabs>
     <SectionWrap
       bg-color="white"
-      short
-    >
+      short>
       <p>(text below the tabs)</p>
     </SectionWrap>
   </div>

--- a/components/welcome/stories/Story1.vue
+++ b/components/welcome/stories/Story1.vue
@@ -4,7 +4,8 @@
       name="Professor Glynn Davis"
       title="Vice Chancellor"
       caption-text="The Vice-Chancellor is the Chief Executive Officer of the University."
-      btn-text="Bio and Recent Publications">
+      btn-text="Bio and Recent Publications"
+    >
       <h2>Welcome from the Vice-Chancellor</h2>
       <p>The academic enterprise is crucial in society. At the University of Melbourne, we support the highest quality research aimed at resolving serious challenges, both in the domain of knowledge and in people’s lives.</p>
       <p>We also take delight in helping undergraduate and postgraduate students become leaders who are academically outstanding, practically grounded and socially responsible. Thank you for taking the time to visit us.</p>
@@ -17,5 +18,6 @@ import Welcome from '../Welcome.vue';
 
 export default {
   components: { Welcome },
+  readme: { source: true, html: true },
 };
 </script>

--- a/components/welcome/stories/Story2.vue
+++ b/components/welcome/stories/Story2.vue
@@ -16,5 +16,6 @@ import Welcome from '../Welcome.vue';
 
 export default {
   components: { Welcome },
+  readme: { source: true, html: true },
 };
 </script>

--- a/targets/lib/index.js
+++ b/targets/lib/index.js
@@ -27,6 +27,36 @@ import InPageNavigation from '../../components/page/navigation/InPageNavigation.
 import OutPageNavigation from '../../components/page/navigation/OutPageNavigation.vue';
 import FocusWrapper from '../../components/focus-wrapper/FocusWrapper.vue';
 import SvgIcon from '../../components/icons/SvgIcon.vue';
+import ListingWrap from '../../components/listing/ListingWrap.vue';
+import ListItem from '../../components/listing/ListItem.vue';
+import ArticleWrap from '../../components/article-wrap/ArticleWrap.vue';
+import BlockQuotation from '../../components/block-quotation/BlockQuotation.vue';
+import ButtonIcon from '../../components/buttons/ButtonIcon.vue';
+import GenericCard from '../../components/cards/GenericCard.vue';
+import ContactList from '../../components/contact-list/ContactList.vue';
+import ContentBlock from '../../components/content-block/ContentBlock.vue';
+import Dropdown from '../../components/dropdown/Dropdown.vue';
+import VideoEmbed from '../../components/embed/VideoEmbed.vue';
+import SoundcloudEmbed from '../../components/embed/SoundcloudEmbed.vue';
+import FigureWrap from '../../components/figure/FigureWrap.vue';
+import Notice from '../../components/notice/Notice.vue';
+import PageBreadcrumbs from '../../components/page/breadcrumbs/PageBreadcrumbs.vue';
+import PageHeader from '../../components/page/header/PageHeader.vue';
+import PageHeaderMin from '../../components/page/header/PageHeaderMin.vue';
+import Pathfinder from '../../components/pathfinder/Pathfinder.vue';
+import SectionDivider from '../../components/section/SectionDivider.vue';
+import SectionTwoCol from '../../components/section/SectionTwoCol.vue';
+import SectionWrap from '../../components/section/SectionWrap.vue';
+import SplitSection from '../../components/section/SplitSection.vue';
+import SplitSectionQuote from '../../components/section/SplitSectionQuote.vue';
+import SidePanel from '../../components/side-panel/SidePanel.vue';
+import SidePanelNavItem from '../../components/side-panel/SidePanelNavItem.vue';
+import SocialList from '../../components/social-list/SocialList.vue';
+import StatsGroup from '../../components/stats/StatsGroup.vue';
+import StatsItem from '../../components/stats/StatsItem.vue';
+import SublinkMenu from '../../components/sublink-menu/SublinkMenu.vue';
+import SublinkMenuItem from '../../components/sublink-menu/SublinkMenuItem.vue';
+import Welcome from '../../components/welcome/Welcome.vue';
 
 
 import '../../components';
@@ -60,6 +90,37 @@ Vue.component('in-page-navigation', InPageNavigation);
 Vue.component('out-page-navigation', OutPageNavigation);
 Vue.component('focus-wrapper', FocusWrapper);
 Vue.component('svg-icon', SvgIcon);
+Vue.component('listing-wrap', ListingWrap);
+Vue.component('list-item', ListItem);
+Vue.component('article-wrap', ArticleWrap);
+Vue.component('block-quotation', BlockQuotation);
+Vue.component('button-icon', ButtonIcon);
+Vue.component('generic-card', GenericCard);
+Vue.component('contact-list', ContactList);
+Vue.component('content-block', ContentBlock);
+Vue.component('dropdown', Dropdown);
+Vue.component('video-embed', VideoEmbed);
+Vue.component('sound-cloud-embed', SoundcloudEmbed);
+Vue.component('figure-wrap', FigureWrap);
+Vue.component('notice', Notice);
+Vue.component('page-breadcrumbs', PageBreadcrumbs);
+Vue.component('page-header', PageHeader);
+Vue.component('page-header-min', PageHeaderMin);
+Vue.component('pathfinder', Pathfinder);
+Vue.component('section-divider', SectionDivider);
+Vue.component('section-two-col', SectionTwoCol);
+Vue.component('section-wrap', SectionWrap);
+Vue.component('split-section', SplitSection);
+Vue.component('slit-section-quote', SplitSectionQuote);
+Vue.component('side-panel', SidePanel);
+Vue.component('side-panel-nav-item', SidePanelNavItem);
+Vue.component('social-list', SocialList);
+Vue.component('stats-group', StatsGroup);
+Vue.component('stats-item', StatsItem);
+Vue.component('sublink-menu', SublinkMenu);
+Vue.component('sublink-menu-item', SublinkMenuItem);
+Vue.component('welcome', Welcome);
+
 
 // Create Vue instance
 new Vue({

--- a/targets/lib/index.js
+++ b/targets/lib/index.js
@@ -57,6 +57,8 @@ import StatsItem from '../../components/stats/StatsItem.vue';
 import SublinkMenu from '../../components/sublink-menu/SublinkMenu.vue';
 import SublinkMenuItem from '../../components/sublink-menu/SublinkMenuItem.vue';
 import Welcome from '../../components/welcome/Welcome.vue';
+import CardImage from '../../components/cards/CardImage.vue';
+import CardLink from '../../components/cards/CardLink.vue';
 
 
 import '../../components';
@@ -120,6 +122,8 @@ Vue.component('stats-item', StatsItem);
 Vue.component('sublink-menu', SublinkMenu);
 Vue.component('sublink-menu-item', SublinkMenuItem);
 Vue.component('welcome', Welcome);
+Vue.component('card-image', CardImage);
+Vue.component('card-link', CardLink);
 
 
 // Create Vue instance

--- a/targets/vue/index.js
+++ b/targets/vue/index.js
@@ -67,6 +67,10 @@ export {
 }
   from '../../components/cards/CardStaffList.vue';
 export {
+  default as GenericCard,
+}
+  from '../../components/cards/GenericCard.vue';
+export {
   default as CheckList,
 }
   from '../../components/check-list/CheckList.vue';
@@ -187,6 +191,10 @@ export {
 }
   from '../../components/section/SplitSection.vue';
 export {
+  default as SplitSectionQuote,
+}
+  from '../../components/section/SplitSectionQuote.vue';
+export {
   default as SidePanel,
 }
   from '../../components/side-panel/SidePanel.vue';
@@ -234,3 +242,7 @@ export {
   default as OutPageNavigation,
 }
   from '../../components/page/navigation/OutPageNavigation.vue';
+export {
+  default as Dropdown,
+}
+  from '../../components/dropdown/Dropdown.vue';


### PR DESCRIPTION
Ticket: [#233](https://github.com/unimelb/ffam-prototype/issues/233)

Update the index.js file to make the components exportable and update their stories showing how to use in raw html and in vue mode. 

- [x] ListingWrap
- [x] ListItem
- [x] ArticleWrap
- [x] BlockQuotation
- [x] ButtonIcon
- [x] GenericCard 
- [x] ContactList
- [x] ContentBlock
- [x] Dropdown
- [x] VideoEmbed
- [x] SoundcloudEmbed
- [x] FigureWrap
- [x] Notice
- [x] PageBreadcrumbs
- [x] PageHeader
- [x] PageHeaderMin
- [x] Pathfinder
- [x] CardImage
- [x] CardLink
- [x] SectionDivider
- [x] SectionTwoCol
- [x] SectionWrap
- [x] SplitSection
- [x] SplitSectionQuote
- [x] SidePanel
- [x] SidePanelNavItem
- [x] SocialList
- [x] StatsGroup
- [x] StatsItem
- [x] SublinkMenu
- [x] SublinkMenuItem
- [x] Welcome


The idea of this PR is to make sure that all the components in the `pattern-lib` are reusable, and the stories show both ways of usage ( Raw HTML and Vue component ).