### PR TITLE
Fix mobile menu overlaying opened menu

### DIFF
--- a/components/page/megamenu/_mega-menu.css
+++ b/components/page/megamenu/_mega-menu.css
@@ -608,11 +608,6 @@
   &:focus-within {
     z-index: 101;
     overflow: visible;
-
-    .megamenu__blanket {
-      z-index: 100;
-      top: 0;
-    }
   }
 
   &__with-top-menu {

--- a/components/page/search/_header-tools.css
+++ b/components/page/search/_header-tools.css
@@ -12,7 +12,6 @@
     margin-right: .25rem;
     margin-left: .25rem;
     color: rgb(var(--col-background-primary-white));
-    z-index: 103;
   }
 
   @media (--bp-tablet) {


### PR DESCRIPTION
Mobile menu shouldn't overlay when menu is opened