### PR TITLE
(fix) improve buttons on mobile layout

### DIFF
--- a/components/buttons/index.css
+++ b/components/buttons/index.css
@@ -38,7 +38,7 @@
   & + & {
     margin-top: 1rem;
 
-    @media (--bp-desktop) {
+    @media (--bp-tablet) {
       margin-top: 0;
       margin-left: 1rem;
     }
@@ -220,7 +220,7 @@
     pointer-events: none;
   }
 
-  @media (--bp-desktop) {
+  @media (--bp-tablet) {
     width: auto;
   }
 }

--- a/components/buttons/index.css
+++ b/components/buttons/index.css
@@ -4,6 +4,7 @@
 .btn {
   display: inline-block;
   padding: calc(var(--vr) * .8);
+  width: 100%;
   transition: border-color .2s;
   border: 2px solid rgb(var(--col-brand));
   border-radius: var(--br);
@@ -32,6 +33,15 @@
     background-color: rgb(var(--col-brand));
     color: rgb(var(--col-background-primary-white));
     text-decoration: none;
+  }
+
+  & + & {
+    margin-top: 1rem;
+
+    @media (--bp-desktop) {
+      margin-top: 0;
+      margin-left: 1rem;
+    }
   }
 
   &--inverted,
@@ -208,5 +218,9 @@
   &--disabled {
     opacity: .5;
     pointer-events: none;
+  }
+
+  @media (--bp-desktop) {
+    width: auto;
   }
 }

--- a/components/buttons/stories/ButtonAdjacent.vue
+++ b/components/buttons/stories/ButtonAdjacent.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <ButtonIcon>Button 1</ButtonIcon>
+    <ButtonIcon>Button 2</ButtonIcon>
+  </div>
+</template>
+
+<script>
+export default {
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/buttons/stories/index.js
+++ b/components/buttons/stories/index.js
@@ -16,6 +16,7 @@ import Story12 from './Story12.vue';
 import Story13 from './Story13.vue';
 import Story14 from './Story14.vue';
 import Story15 from './Story15.vue';
+import ButtonAdjacent from './ButtonAdjacent.vue';
 /* ##Import story component here */
 
 /* Section - Focus  */
@@ -29,6 +30,7 @@ storiesOf('Buttons', module)
   .add('Extra Wide', createStory(Story7))
   .add('Full Width', createStory(Story8))
   .add('All Sizes', createStory(Story9))
+  .add('Adjacent Buttons', createStory(ButtonAdjacent))
   .add('Button as <button> element', createStory(Story10))
   .add('Inverted button', createStory(Story12))
   .add('Button for use in CMS (btn--icon)', createStory(Story11))


### PR DESCRIPTION
Buttons take up 100% of width on mobile/tablet viewports
Adjacent buttons add some spacing between themselves.