### PR TITLE
IE11 fix for card events full width

### DIFF
--- a/components/cards/_card-generic.css
+++ b/components/cards/_card-generic.css
@@ -87,5 +87,11 @@
         padding-top: 0;
       }
     }
+
+    .card__inner {
+      @media (--bp-desktop) {
+        width: 70%;
+      }
+    }
   }
 }


### PR DESCRIPTION
https://deploy-preview-1117--pattern-lib-unimelb.netlify.com/?selectedKind=Cards%2FEvents&selectedStory=Full%20width%20%28horizontal%29&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel

- [x] Check on IE11