### PR TITLE
chore(component) update compacted table header selector

### DIFF
--- a/components/tables/CompactedTable.vue
+++ b/components/tables/CompactedTable.vue
@@ -29,9 +29,9 @@ export default {
       const headings = this.$refs.table.querySelectorAll('thead th');
       const mobileHeadingCell = 0;
 
-      this.hasHeadings = this.$refs.table.querySelectorAll('.table__row--header').length > 0;
+      this.hasHeadings = this.$refs.table.querySelectorAll('.table__header').length > 0;
 
-      for (let rows = this.$refs.table.querySelectorAll('tr:not(.table__row--header)'), i = rows.length - 1; i >= 0; i -= 1) {
+      for (let rows = this.$refs.table.querySelectorAll('tr:not(.table__header)'), i = rows.length - 1; i >= 0; i -= 1) {
         for (let cells = rows[i].querySelectorAll('td'), j = cells.length - 1; j >= 0; j -= 1) {
           if (!this.hasHeadings) {
             cells[mobileHeadingCell].classList.add('table__mobile-title');

--- a/components/tables/_tables-compacted.css
+++ b/components/tables/_tables-compacted.css
@@ -17,7 +17,7 @@
     table-layout: auto;
   }
 
-  tr.table__row--header {
+  tr.table__header {
     td {
       &::before {
         content: none;
@@ -63,7 +63,7 @@
         }
       }
 
-      &:not(.table__row--header) {
+      &:not(.table__header) {
         &::before {
           content: attr(data-mobile-heading);
           display: flex;

--- a/components/tables/_tables-responsive.css
+++ b/components/tables/_tables-responsive.css
@@ -22,7 +22,7 @@
   &__inner {
     table {
       @media (--bp-max-x-mobile) {
-        width: 600px;
+        width: 600px !important;
         table-layout: auto;
         margin-bottom: 0;
       }

--- a/components/tables/stories/TableComplexCompacted.vue
+++ b/components/tables/stories/TableComplexCompacted.vue
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr class="table__row--info table__row--header">
+        <tr class="table__row--info table__header">
           <th colspan="2">
             January using th
           </th>
@@ -49,7 +49,7 @@
             Council Planning Day
           </td>
         </tr>
-        <tr class="table__row--info table__row--header">
+        <tr class="table__row--info table__header">
           <td colspan="2">
             February
           </td>
@@ -78,7 +78,7 @@
             Week O: Orientation for all students
           </td>
         </tr>
-        <tr class="table__row--info table__row--header">
+        <tr class="table__row--info table__header">
           <td colspan="2">
             March
           </td>
@@ -99,7 +99,7 @@
             Labour Day (not a University Holiday)
           </td>
         </tr>
-        <tr class="table__row--info table__row--header">
+        <tr class="table__row--info table__header">
           <td colspan="2">
             April
           </td>

--- a/components/tables/stories/table-compacted-complex.md
+++ b/components/tables/stories/table-compacted-complex.md
@@ -2,7 +2,7 @@
 
 Add the class `table--is-compacted` to the `<table>` to define it as a Compacted Table.
 
-By default the first column becomes the header when viewing the table on mobile viewport. This can be overridden by adding the class `table__row--header` to a `<tr>`.
+By default the first column becomes the header when viewing the table on mobile viewport. This can be overridden by adding the class `table__header` to a `<tr>`.
 
 ### Example:
 
@@ -10,7 +10,7 @@ By default the first column becomes the header when viewing the table on mobile 
 <table class="table--is-compacted">
   <thead>...</thead>
   <tbody>
-    <tr class="table__row--info table__row--header">
+    <tr class="table__header">
       <th>This becomes mobile heading</th>
     </tr>
     ...
@@ -25,7 +25,7 @@ By default the first column becomes the header when viewing the table on mobile 
   <table>
     <thead>...</thead>
     <tbody>
-      <tr class="table__row--info table__row--header">
+      <tr class="table__header">
         <th>This becomes mobile heading</th>
       </tr>
       ...


### PR DESCRIPTION
Made it easier for content editor to set compacted table header.
Set responsive table to `!important` to override content editors inline `width:100%` on table