### PR TITLE
chore(console) Add command to stop vue-axe clearing console

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -51,5 +51,6 @@ if (process.env.NODE_ENV !== 'production') {
         { id: 'label-title-only', enabled: true },
       ],
     },
+    clearConsoleOnUpdate: false,
   });
 }


### PR DESCRIPTION
Stop vue-axe from clearing console.  At the moment it's hard to see any errors etc.