### PR TITLE
chore(carousel) remove component from pattern-lib-vue

### DIFF
--- a/components/carousel/stories/carousel-doc.md
+++ b/components/carousel/stories/carousel-doc.md
@@ -1,5 +1,7 @@
 ## Carousel
 
+**Please note:** This component is **only** available for usage in the CMS.  It is **not** availiable in `pattern-lib-vue`.
+
 The Carousel component receives an Array called `stories` to build the stories slider and story title with description. 
 
 The component has timing option. 

--- a/targets/vue/index.js
+++ b/targets/vue/index.js
@@ -319,10 +319,6 @@ export {
 }
   from '../../components/tables/CompactedTable.vue';
 export {
-  default as Carousel,
-}
-  from '../../components/carousel/Carousel.vue';
-export {
   default as Logo,
 }
   from '../../components/logo/Logo.vue';


### PR DESCRIPTION
A quick fix so we can install newer versions of `pattern-lib-vue` in find a course.