### PR TITLE
chore(linting) Remove rule for @ rule to be at end of class

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -26,7 +26,7 @@
     "no-duplicate-selectors": true,
     "number-leading-zero": "never",
     "number-max-precision": 4,
-    "order/order": ["custom-properties", "declarations", "rules", "at-rules"],
+    "order/order": ["custom-properties", "declarations", "rules"],
     "property-no-vendor-prefix": true,
     "selector-attribute-quotes": "always",
     "selector-list-comma-newline-before": "never-multi-line",


### PR DESCRIPTION
Currently there is a rule to force `@` rules to be at the bottom of a class.  This causes issues with media queries in this situation:

```html
.box {
  width: 50px;
  height: 50px;
  background: black;

  &--alt {
    background: orange;

    @media (--bp-desktop) { 
      background: green;
    }
  }

  @media (--bp-desktop) { 
    background: red;
  }
}
```

```<div class="box box--alt"></div>``` should be _green_ but because of the rule ordering it is instead _red_;

By allowing `@` rule to be at the top this will now be allowed and show the correct colours:

```
.box {
  width: 50px;
  height: 50px;
  background: black;
  
  @media (--bp-desktop) { 
    background: red;
  }

  &--alt { 
    background: orange;

    @media (--bp-desktop) { 
      background: green;
    }
  }
}```