### PR TITLE
chore(component) Tabs - hide select if there is only one tab

### DIFF
--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -4,6 +4,7 @@
     class="tabs section">
     <div class="tabs__section max">
       <div
+        v-if="selectOptions.length > 1"
         :class="classes">
         <div
           v-if="title"

--- a/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -7,17 +7,7 @@ exports[`Tabs should be alternate tab with yellow border 1`] = `
   <div
     class="tabs__section max"
   >
-    <div
-      class="tabs__dropdown tabs__dropdown--mobile"
-    >
-      <!---->
-       
-      <div
-        class="tabs__dropdown-select"
-      >
-        <!---->
-      </div>
-    </div>
+    <!---->
      
     <div
       class="tabs__tablist tabs__tablist--alt tabs__tablist--yellow"
@@ -39,17 +29,7 @@ exports[`Tabs should match snapshot 1`] = `
   <div
     class="tabs__section max"
   >
-    <div
-      class="tabs__dropdown tabs__dropdown--mobile"
-    >
-      <!---->
-       
-      <div
-        class="tabs__dropdown-select"
-      >
-        <!---->
-      </div>
-    </div>
+    <!---->
      
     <div
       class="tabs__tablist"

--- a/components/tabs/stories/TabsSelect.vue
+++ b/components/tabs/stories/TabsSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Tabs
-      title="Selector prefix"
+      title="Selector with really big prefix"
       label="options available"
       use-select
       show-count>
@@ -226,23 +226,6 @@
             The information on this form is being collected by the University of Melbourne for further communication regarding various courses, programs and events at the University in which you have expressed interest. Information collected will only be used by authorised staff for the purpose for which it was collected and will be protected against unauthorized access and use. You can access any personal information the University holds about you. Contact the <a href="http://www.unimelb.edu.au/governance/compliance/privacy/contacts">Privacy Officer</a> to find out more. The <a href="http://www.unimelb.edu.au/governance/compliance/privacy">University’s Privacy Policy</a> is available online.
           </p>
         </form>
-      </Tab>
-    </Tabs>
-
-    <Tabs
-      title="Selector with really big prefix"
-      label="options available"
-      use-select
-      show-count>
-      <Tab title="Use">
-        <p>We write using the conventions and principles of modern Australian English.</p>
-        <p> Our style is simple and accessible, and often conversational in tone. We avoid archaic language, euphemisms and slang. Australian English is continuously evolving, so always refer to the latest edition of the Macquarie Dictionary (Macquarie Dictionary Publishers) and Style Manual: For Authors, Editors and Printers (John Wiley & Sons) for Australia’s most up-to-date spelling and grammar conventions.</p>
-        <ButtonIcon size="xsml">
-          I am a child component
-        </ButtonIcon>
-      </Tab>
-      <Tab title="Inclusive language">
-        <p>We always use inclusive language, avoiding stereotypical and offensive terms that unnecessarily categorise people by attributes such as race, gender or disability. For example, say ‘student’ rather than ‘Asian student’, ‘chairperson’ in place of ‘chairman’ and ‘person with a disability’ instead of ‘disabled person’.</p>
       </Tab>
     </Tabs>
   </div>

--- a/components/tabs/stories/tabsSelect.md
+++ b/components/tabs/stories/tabsSelect.md
@@ -7,3 +7,7 @@ The following optional props are only usable with `use-select`:
 - `title` (title to show to the left of the select)
 - `label` (set label of 'bubble' above select)
 - `show-count` (counts tabs and displays accumulated count)
+
+### Note
+
+If only one tab is present then the select dropdown will be hidden.


### PR DESCRIPTION
# Description

If there is only one `<tab>` inside the `<tabs>` component and `use-select` has been set, then hide the select dropdown.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] Make sure to do not repeat yourself
- [x] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
