### PR TITLE
feat(redesign): card staff list

### DIFF
--- a/components/cards/CardStaffList.vue
+++ b/components/cards/CardStaffList.vue
@@ -3,8 +3,8 @@
     <a
       :href="href"
       :style="{ backgroundImage: `url(${thumb})` }"
-      :title="'profile of' + name"
-      :aria-label="'Photo of' + name"
+      :title="'profile of ' + name"
+      :aria-label="'Photo of ' + name"
       class="card__thumb" />
     <div class="card__inner">
       <a

--- a/components/cards/__tests__/__snapshots__/CardStaffList.test.js.snap
+++ b/components/cards/__tests__/__snapshots__/CardStaffList.test.js.snap
@@ -5,11 +5,11 @@ exports[`CardStaffList should match snapshot 1`] = `
   class="btn-owner card card--stafflist card--bdr-blue bg-white"
 >
   <a
-    aria-label="Photo ofTest name"
+    aria-label="Photo of Test name"
     class="card__thumb"
     href="#"
     style="background-image: url(https://matrix-cms.unimelb.edu.au/__data/assets/image/0022/82903/pattern-library-staff-placeholder.png);"
-    title="profile ofTest name"
+    title="profile of Test name"
   />
    
   <div

--- a/components/cards/_card-stafflist.css
+++ b/components/cards/_card-stafflist.css
@@ -4,6 +4,8 @@
     display: flex;
     flex: 1 0 auto;
     flex-direction: column;
+    border-left: 1px solid rgb(var(--col-navy-mid-1));
+    border-right: 1px solid rgb(var(--col-navy-mid-1));
   }
 
   .card__thumb {

--- a/components/forms/_select.css
+++ b/components/forms/_select.css
@@ -44,9 +44,9 @@
     content: '';
     position: absolute;
     top: 50%;
-    right: 0.3125rem;
-    width: 0.875rem;
-    height: 0.875rem;
+    right: .3125rem;
+    width: .875rem;
+    height: .875rem;
     pointer-events: none;
     background-image: svg-load('chevron-down.svg', fill=rgb(var(--col-blue-mid-2)));
     transform: translate(-65%, -50%);


### PR DESCRIPTION
# Description

Building the new pages of short-courses for FAC, the card staff list because is been used in a white background we had the necessity to implement borders to make it stand out from the white background and looks better, this redesign will fix the problem of the usage in this card in white background.

preview: 

https://deploy-preview-1394--pattern-lib-unimelb.netlify.com/?selectedKind=Cards%2FStaff%20List%2FBios&selectedStory=Staff%20bios&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Make sure to do not repeat yourself
- [x] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added the new component to the index.js (Vue and Lib) export
