### PR TITLE
chore(linting) Improve code-base: no magic numbers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,7 +78,8 @@
     "no-magic-numbers": [
       "warn",
       { 
-        "ignoreArrayIndexes": true
+        "ignoreArrayIndexes": true,
+        "ignore": [1]
       }
     ],
     "radix": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -75,8 +75,7 @@
     "no-magic-numbers": [
       "warn",
       { 
-        "ignoreArrayIndexes": true,
-        "ignore": [0, 1, 2, 3, 4] 
+        "ignoreArrayIndexes": true
       }
     ],
     "radix": "error",
@@ -114,5 +113,13 @@
     "vue/key-spacing": "error",
     "vue/space-infix-ops": "error",
     "vue/object-curly-spacing": ["error","always"]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.test.js"],
+      "rules": {
+        "no-magic-numbers": "off"
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,7 @@
     ],
     "no-useless-concat": "error",
     "no-case-declarations": "off",
-    "no-magic-numbers": "off",
+    "no-magic-numbers": "warn",
     "radix": "error",
     "vue/attribute-hyphenation": "error",
     "vue/html-quotes": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,13 @@
     ],
     "no-useless-concat": "error",
     "no-case-declarations": "off",
-    "no-magic-numbers": "warn",
+    "no-magic-numbers": [
+      "warn",
+      { 
+        "ignoreArrayIndexes": true,
+        "ignore": [0, 1, 2, 3, 4] 
+      }
+    ],
     "radix": "error",
     "vue/attribute-hyphenation": "error",
     "vue/html-quotes": "error",

--- a/components/article-wrap/ArticleWrap.vue
+++ b/components/article-wrap/ArticleWrap.vue
@@ -16,7 +16,7 @@
         <time :datetime="date[0]">{{ date[1] }}</time> | <span class="article-wrap__type">{{ type }}</span>
       </div>
       <div
-        v-if="categories && categories.length > 0"
+        v-if="categories && categories.length"
         class="article-wrap__aside-box article-wrap__categories">
         <p class="article-wrap__categories-heading">
           Categories
@@ -67,7 +67,7 @@ export default {
     date: {
       type: Array, // e.g. ['1970-01-01', '1 Jan. 1970']
       validator: (arr) => (
-        arr.length === 0
+        !arr.length
         || (arr.length === 2
         && arr.every((item) => typeof item === 'string'))
       ),
@@ -83,7 +83,7 @@ export default {
     },
     categories: {
       type: Array,
-      validator: (arr) => arr.length === 0 || arr.every((item) => typeof item === 'string'),
+      validator: (arr) => !arr.length || arr.every((item) => typeof item === 'string'),
       default: () => [],
     },
   },

--- a/components/article-wrap/ArticleWrap.vue
+++ b/components/article-wrap/ArticleWrap.vue
@@ -66,11 +66,11 @@ export default {
     },
     date: {
       type: Array, // e.g. ['1970-01-01', '1 Jan. 1970']
-      validator: (arr) => (
-        !arr.length
-        || (arr.length === 2
-        && arr.every((item) => typeof item === 'string'))
-      ),
+      validator: (arr) => {
+        const maxDates = 2;
+
+        return (!arr.length || (arr.length === maxDates && arr.every((item) => typeof item === 'string')));
+      },
       default: () => [],
     },
     type: {

--- a/components/breadcrumbs/PageBreadcrumbs.vue
+++ b/components/breadcrumbs/PageBreadcrumbs.vue
@@ -50,7 +50,7 @@ export default {
       type: Array,
       required: true,
       validator: (arr) => (
-        arr.length > 0
+        arr.length
         && arr.every((el) => !!el.href && !!el.text)
       ),
     },

--- a/components/buttons/ButtonIcon.vue
+++ b/components/buttons/ButtonIcon.vue
@@ -49,7 +49,7 @@ export default {
     iconSize: {
       type: String,
       default: 'md',
-      validator: (value) => ['md', 'lg'].indexOf(value) !== -1,
+      validator: (value) => ['md', 'lg'].includes(value),
     },
     inverted: {
       type: Boolean,
@@ -66,7 +66,7 @@ export default {
     element: {
       type: String,
       default: 'a',
-      validator: (val) => ['a', 'button', 'div', 'span'].indexOf(val) !== -1,
+      validator: (val) => ['a', 'button', 'div', 'span'].includes(val),
     },
     disabled: {
       type: Boolean,

--- a/components/cards/CardFocusBox.vue
+++ b/components/cards/CardFocusBox.vue
@@ -36,7 +36,7 @@ export default {
     color: {
       type: String,
       default: '',
-      validator: (color) => ['', 'navy', 'teal', 'yellow', 'emerald', 'orange', 'green', 'purple', 'pink'].indexOf(color) > -1,
+      validator: (color) => ['', 'navy', 'teal', 'yellow', 'emerald', 'orange', 'green', 'purple', 'pink'].includes(color),
     },
     href: {
       type: String,

--- a/components/cards/CardFocusImageList.vue
+++ b/components/cards/CardFocusImageList.vue
@@ -103,7 +103,7 @@ export default {
   computed: {
     classes() {
       return {
-        [`card--image-focus--col-${this.color}`]: this.color && this.color.length > 0,
+        [`card--image-focus--col-${this.color}`]: this.color && this.color.length,
         'btn-owner': this.element && this.element === 'a',
         'card--image-no-focus': !!this.noFocus,
       };

--- a/components/cards/CardImage.vue
+++ b/components/cards/CardImage.vue
@@ -3,7 +3,7 @@
     :href="href"
     class="btn-owner card card--image card--bdr bg-inverted">
     <div
-      v-if="thumb && thumb.length > 0"
+      v-if="thumb && thumb.length"
       :style="{ backgroundImage: `url(${thumb})` }"
       :aria-label="title"
       class="card__thumb card__thumb--zoom" />

--- a/components/cards/CardLink.vue
+++ b/components/cards/CardLink.vue
@@ -49,7 +49,11 @@ export default {
     cols: {
       type: Number,
       default: 4,
-      validator: (cols) => cols && cols <= 4,
+      validator: (cols) => {
+        const maxColumns = 4;
+
+        return cols && cols <= maxColumns;
+      },
     },
   },
   computed: {

--- a/components/cards/CardNewsTag.vue
+++ b/components/cards/CardNewsTag.vue
@@ -46,7 +46,11 @@ export default {
     cols: {
       type: Number,
       default: 1,
-      validator: (value) => value && value <= 3,
+      validator: (value) => {
+        const maxColumns = 3;
+
+        return value && value <= maxColumns;
+      },
     },
   },
 };

--- a/components/cards/CardStaffList.vue
+++ b/components/cards/CardStaffList.vue
@@ -96,7 +96,9 @@ export default {
   },
   computed: {
     renderFooter() {
-      return this.cols < 4 && (this.phone || this.email);
+      const maxColumns = 4;
+
+      return this.cols < maxColumns && (this.phone || this.email);
     },
   },
 };

--- a/components/cards/CardStat.vue
+++ b/components/cards/CardStat.vue
@@ -35,12 +35,21 @@ export default {
     stat: {
       type: String,
       default: '123456',
-      validator: (value) => value.length > 0 && value.length <= 6,
+      validator: (value) => {
+        const maxLength = 6;
+
+        return value.length && value.length <= maxLength;
+      },
     },
     cols: {
       type: Number,
       default: 3,
-      validator: (value) => value >= 2 && value <= 3,
+      validator: (value) => {
+        const minColumns = 2;
+        const maxColumns = 3;
+
+        return value >= minColumns && value <= maxColumns;
+      },
     },
     inverted: {
       type: Boolean,
@@ -51,7 +60,7 @@ export default {
     classes() {
       return {
         'card--focus-box-vert': this.vertical,
-        [`card--focus-box--${this.color}`]: this.color && this.color.length > 0,
+        [`card--focus-box--${this.color}`]: this.color && this.color.length,
         'card--stat btn-owner card card--focus-box bg-inverted': this.inverted,
         'card--stat btn-owner card card--focus-box bg-white': !this.inverted,
       };

--- a/components/cards/GenericCard.vue
+++ b/components/cards/GenericCard.vue
@@ -59,7 +59,11 @@ export default {
     cols: {
       type: Number,
       default: 3,
-      validator: (value) => value && value <= 3,
+      validator: (value) => {
+        const maxColumns = 3;
+
+        return value && value <= maxColumns;
+      },
     },
     href: {
       type: String,

--- a/components/cards/__tests__/CardLink.test.js
+++ b/components/cards/__tests__/CardLink.test.js
@@ -88,6 +88,7 @@ describe('CardLink', () => {
     const { cols } = wrapper.vm.$options.props;
 
     expect(cols.validator && cols.validator(0)).toBeFalsy();
+    // eslint-disable-next-line no-magic-numbers
     expect(cols.validator && cols.validator(5)).toBeFalsy();
   });
 

--- a/components/cards/__tests__/CardLink.test.js
+++ b/components/cards/__tests__/CardLink.test.js
@@ -88,7 +88,6 @@ describe('CardLink', () => {
     const { cols } = wrapper.vm.$options.props;
 
     expect(cols.validator && cols.validator(0)).toBeFalsy();
-    // eslint-disable-next-line no-magic-numbers
     expect(cols.validator && cols.validator(5)).toBeFalsy();
   });
 

--- a/components/carousel/Carousel.vue
+++ b/components/carousel/Carousel.vue
@@ -286,7 +286,10 @@ export default {
       this.actionProgressBar();
     },
     frame() {
-      this.progressBarWidth = Math.round((this.countTime / this.autoplay) * 100) + 5;
+      const initialWidth = 5;
+      const percent = 100;
+
+      this.progressBarWidth = Math.round((this.countTime / this.autoplay) * percent) + initialWidth;
       this.countTime += 200;
     },
     actionProgressBar() {

--- a/components/carousel/Carousel.vue
+++ b/components/carousel/Carousel.vue
@@ -171,6 +171,8 @@ export default {
   },
   filters: {
     truncate(value, limit, ellipsis = '') {
+      const startFromIndex = 0;
+
       if (!value) {
         return '';
       }
@@ -179,14 +181,18 @@ export default {
         return value;
       }
 
-      return `${value.substring(0, limit)}${ellipsis}`;
+      return `${value.substring(startFromIndex, limit)}${ellipsis}`;
     },
   },
   props: {
     stories: {
       type: Array,
       default: () => [],
-      validator: (stories) => stories.length <= 3,
+      validator: (stories) => {
+        const maxStories = 3;
+
+        return stories.length <= maxStories;
+      },
       required: true,
     },
     timing: {
@@ -244,7 +250,9 @@ export default {
     },
   },
   created() {
-    this.displayImage(0);
+    const startFromPositionIndex = 0;
+
+    this.displayImageAtPosition(startFromPositionIndex);
   },
   mounted() {
     this.loadImg();
@@ -253,7 +261,7 @@ export default {
     }, TIMER_1100);
   },
   methods: {
-    displayImage(index) {
+    displayImageAtPosition(index) {
       this.image[index] = {
         backgroundImage: `url(${this.stories[index].src})`,
         backgroundPosition: this.stories[index].imagePosition ? this.stories[index].imagePosition : 'center',
@@ -262,7 +270,7 @@ export default {
     loadImg() {
       setTimeout(() => {
         for (let i = 1; i < this.stories.length; i += 1) {
-          this.displayImage(i);
+          this.displayImageAtPosition(i);
         }
       }, TIMER_1100);
     },
@@ -316,7 +324,7 @@ export default {
       this.countTime = 0;
     },
     moveToStory(storyIndex) {
-      this.displayImage(storyIndex);
+      this.displayImageAtPosition(storyIndex);
       this.selectedItem = this.stories[storyIndex];
       this.selectedIndex = storyIndex;
       this.$refs.slider.$emit('slideTo', storyIndex);

--- a/components/carousel/Carousel.vue
+++ b/components/carousel/Carousel.vue
@@ -160,6 +160,8 @@ import { slider, slideritem } from 'vue-concise-slider';
 import SvgIcon from '../icons/SvgIcon.vue';
 import ButtonIcon from '../buttons/ButtonIcon.vue';
 
+import { TIMER_1100, TIMER_200 } from '../../constants/timers';
+
 export default {
   components: {
     slider,
@@ -248,7 +250,7 @@ export default {
     this.loadImg();
     setTimeout(() => {
       this.actionProgressBar();
-    }, 1100);
+    }, TIMER_1100);
   },
   methods: {
     displayImage(index) {
@@ -262,7 +264,7 @@ export default {
         for (let i = 1; i < this.stories.length; i += 1) {
           this.displayImage(i);
         }
-      }, 1100);
+      }, TIMER_1100);
     },
     slide(slide) {
       if (this.stories[slide.currentPage]) {
@@ -290,7 +292,7 @@ export default {
     actionProgressBar() {
       clearInterval(this.interval);
       this.interval = null;
-      this.interval = setInterval(() => this.frame(), 200);
+      this.interval = setInterval(() => this.frame(), TIMER_200);
     },
     clearFrame() {
       if (!this.paused) {

--- a/components/check-list/CheckList.vue
+++ b/components/check-list/CheckList.vue
@@ -48,7 +48,7 @@ export default {
   },
   computed: {
     itemsAllChecked() {
-      return this.checkedItems.indexOf(false) === -1;
+      return !this.checkedItems.includes(false);
     },
     namespace() {
       return `ui-checklist-${this._uid}`;

--- a/components/content-block/ContentBlock.vue
+++ b/components/content-block/ContentBlock.vue
@@ -10,7 +10,7 @@ export default {
     size: {
       type: String,
       default: '',
-      validator: (value) => ['', 'sml', 'lge'].indexOf(value) !== -1,
+      validator: (value) => ['', 'sml', 'lge'].includes(value),
     },
     short: {
       type: Boolean,

--- a/components/embed/SoundcloudEmbed.vue
+++ b/components/embed/SoundcloudEmbed.vue
@@ -24,7 +24,7 @@ export default {
     mode: {
       type: String,
       default: 'classic',
-      validator: (value) => ['classic', 'visual'].indexOf(value) !== -1,
+      validator: (value) => ['classic', 'visual'].includes(value),
     },
   },
   computed: {

--- a/components/embed/VideoEmbed.vue
+++ b/components/embed/VideoEmbed.vue
@@ -26,7 +26,7 @@ export default {
     ratio: {
       type: String,
       default: '',
-      validator: (value) => ['', '21_9'].indexOf(value) !== -1,
+      validator: (value) => ['', '21_9'].includes(value),
     },
     inset: {
       type: Boolean,

--- a/components/focus-wrapper/FocusWrapper.vue
+++ b/components/focus-wrapper/FocusWrapper.vue
@@ -34,7 +34,7 @@ export default {
     color: {
       type: String,
       default: '',
-      validator: (color) => ['', 'navy', 'teal', 'yellow', 'emerald', 'orange', 'green', 'purple', 'pink'].indexOf(color) > -1,
+      validator: (color) => ['', 'navy', 'teal', 'yellow', 'emerald', 'orange', 'green', 'purple', 'pink'].includes(color),
     },
     semiOpaque: {
       type: Boolean,
@@ -43,7 +43,7 @@ export default {
     size: {
       type: String,
       default: 'medium',
-      validator: (size) => ['small', 'medium', 'large'].indexOf(size) > -1,
+      validator: (size) => ['small', 'medium', 'large'].includes(size),
     },
     padded: {
       type: Boolean,

--- a/components/focus-wrapper/__tests__/FocusWrapper.test.js
+++ b/components/focus-wrapper/__tests__/FocusWrapper.test.js
@@ -44,7 +44,6 @@ describe('FocusWrapper', () => {
     expect(wrapper.props().color).toBe('');
     expect(wrapper.props().semiOpaque).toBe(false);
     expect(wrapper.props().size).toBe('medium');
-    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(72);
     expect(wrapper.props().padded).toBe(false);
     expect(wrapper.classes().includes('card-focus--padded')).toBe(false);
@@ -79,7 +78,6 @@ describe('FocusWrapper', () => {
     });
     const { size } = wrapper.vm.$options.props;
     expect(size.type).toBe(String);
-    // eslint-disable-next-line no-magic-numbers
     expect(size.validator && size.validator(72)).toBeFalsy();
   });
 
@@ -90,7 +88,6 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('small');
-    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(48);
   });
 
@@ -101,7 +98,6 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('medium');
-    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(72);
   });
 
@@ -112,7 +108,6 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('large');
-    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(96);
   });
 

--- a/components/focus-wrapper/__tests__/FocusWrapper.test.js
+++ b/components/focus-wrapper/__tests__/FocusWrapper.test.js
@@ -44,9 +44,10 @@ describe('FocusWrapper', () => {
     expect(wrapper.props().color).toBe('');
     expect(wrapper.props().semiOpaque).toBe(false);
     expect(wrapper.props().size).toBe('medium');
+    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(72);
     expect(wrapper.props().padded).toBe(false);
-    expect(wrapper.classes().indexOf('card-focus--padded')).toBe(-1);
+    expect(wrapper.classes().includes('card-focus--padded')).toBe(false);
   });
 
   it('should accept only correct color value', () => {
@@ -78,6 +79,7 @@ describe('FocusWrapper', () => {
     });
     const { size } = wrapper.vm.$options.props;
     expect(size.type).toBe(String);
+    // eslint-disable-next-line no-magic-numbers
     expect(size.validator && size.validator(72)).toBeFalsy();
   });
 
@@ -88,6 +90,7 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('small');
+    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(48);
   });
 
@@ -98,6 +101,7 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('medium');
+    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(72);
   });
 
@@ -108,6 +112,7 @@ describe('FocusWrapper', () => {
       },
     });
     expect(wrapper.props().size).toBe('large');
+    // eslint-disable-next-line no-magic-numbers
     expect(wrapper.vm.normalizeSize).toBe(96);
   });
 
@@ -119,6 +124,6 @@ describe('FocusWrapper', () => {
     });
 
     expect(wrapper.props().padded).toBe(true);
-    expect(wrapper.classes().indexOf('card-focus--padded')).toBeGreaterThan(-1);
+    expect(wrapper.classes().includes('card-focus--padded')).toBe(true);
   });
 });

--- a/components/forms/StyledSelect.vue
+++ b/components/forms/StyledSelect.vue
@@ -101,7 +101,7 @@ export default {
     setDefaultValue() {
       const defaultSlot = this.$slots.default;
       const filterResult = (items) => items.filter((child) => child.tag === 'option');
-      const filterDefaultValue = (items) => items.map((value) => value.children[0].text).slice(0, 1);
+      const filterDefaultValue = (items) => items.map((value) => value.children[0].text);
 
       if (defaultSlot && defaultSlot.length) {
         // Only grab <option>

--- a/components/header/PageHeader.vue
+++ b/components/header/PageHeader.vue
@@ -34,7 +34,11 @@ export default {
     level: {
       type: Number,
       default: 1,
-      validator: (val) => [1, 2].includes(val),
+      validator: (val) => {
+        const validLevels = [1, 2]; // eslint-disable-line no-magic-numbers
+
+        return validLevels.includes(val);
+      },
     },
     title: {
       type: String,

--- a/components/header/PageHeader.vue
+++ b/components/header/PageHeader.vue
@@ -34,7 +34,7 @@ export default {
     level: {
       type: Number,
       default: 1,
-      validator: (val) => [1, 2].indexOf(val) !== -1,
+      validator: (val) => [1, 2].includes(val),
     },
     title: {
       type: String,

--- a/components/icons/SvgIcon.vue
+++ b/components/icons/SvgIcon.vue
@@ -18,12 +18,15 @@ export default {
   name: 'SvgIcon',
   filters: {
     capitalize(value) {
+      const startFromCharIndex = 0;
+
       let capitalisation = value;
       if (!capitalisation) {
         return '';
       }
       capitalisation = capitalisation.toString();
-      return capitalisation.charAt(0).toUpperCase() + capitalisation.slice(1);
+
+      return capitalisation.charAt(startFromCharIndex).toUpperCase() + capitalisation.slice(1);
     },
   },
   props: ['name', 'width', 'height', 'viewBox'],

--- a/components/logo/Logo.vue
+++ b/components/logo/Logo.vue
@@ -18,7 +18,7 @@ export default {
     size: {
       type: String,
       default: 'lg',
-      validator: (value) => ['sm', 'md', 'lg'].indexOf(value) !== -1,
+      validator: (value) => ['sm', 'md', 'lg'].includes(value),
     },
     noPadding: {
       type: Boolean,

--- a/components/media-gallery/MediaGallery.vue
+++ b/components/media-gallery/MediaGallery.vue
@@ -313,7 +313,7 @@ export default {
     },
     stopVideo() {
       const iframe = document.querySelectorAll('iframe');
-      if (iframe.length > 0) {
+      if (iframe.length) {
         iframe.forEach((element) => {
           const iframeSrc = element.src;
           element.src = iframeSrc;

--- a/components/media-gallery/MediaGallery.vue
+++ b/components/media-gallery/MediaGallery.vue
@@ -147,6 +147,8 @@ import VideoEmbed from '../embed/VideoEmbed.vue';
 import SvgIcon from '../icons/SvgIcon.vue';
 import ThumbnailGallery from './ThumbnailGallery.vue';
 
+import { KEYCODE_ESC, KEYCODE_LEFT, KEYCODE_RIGHT } from '../../constants/keycodes';
+
 export default {
   components: {
     VideoEmbed,
@@ -331,13 +333,13 @@ export default {
     keyBoardActions(e) {
       // Only if component is in viewport.
       if (this.isInViewport) {
-        if (e.keyCode === 37) {
+        if (e.keyCode === KEYCODE_LEFT) {
           this.move('prev');
         }
-        if (e.keyCode === 39) {
+        if (e.keyCode === KEYCODE_RIGHT) {
           this.move('next');
         }
-        if (e.keyCode === 27) {
+        if (e.keyCode === KEYCODE_ESC) {
           this.openState = false;
         }
       }

--- a/components/media-gallery/MediaGallery.vue
+++ b/components/media-gallery/MediaGallery.vue
@@ -148,6 +148,7 @@ import SvgIcon from '../icons/SvgIcon.vue';
 import ThumbnailGallery from './ThumbnailGallery.vue';
 
 import { KEYCODE_ESC, KEYCODE_LEFT, KEYCODE_RIGHT } from '../../constants/keycodes';
+import { TIMER_100 } from '../../constants/timers';
 
 export default {
   components: {
@@ -228,7 +229,7 @@ export default {
   mounted() {
     window.addEventListener('keyup', this.keyBoardActions);
 
-    this.debouncedMediaGalleryScrollEvent = debounce(this.checkInViewport, 100);
+    this.debouncedMediaGalleryScrollEvent = debounce(this.checkInViewport, TIMER_100);
     window.addEventListener('scroll', this.debouncedMediaGalleryScrollEvent);
   },
   beforeDestroy() {

--- a/components/media-gallery/MediaGallery.vue
+++ b/components/media-gallery/MediaGallery.vue
@@ -360,8 +360,11 @@ export default {
       const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
       const windowWidth = (window.innerWidth || document.documentElement.clientWidth);
 
-      const vertInView = (elementRect.top <= windowHeight) && ((elementRect.top + elementRect.height) >= 0);
-      const horInView = (elementRect.left <= windowWidth) && ((elementRect.left + elementRect.width) >= 0);
+      const offsetTop = 0;
+      const offsetLeft = 0;
+
+      const vertInView = (elementRect.top <= windowHeight) && ((elementRect.top + elementRect.height) >= offsetTop);
+      const horInView = (elementRect.left <= windowWidth) && ((elementRect.left + elementRect.width) >= offsetLeft);
 
       return (vertInView && horInView);
     },

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -186,6 +186,17 @@ import MegaMenuTitle from './MegaMenuTitle.vue';
 import MegaMenuTopNavigation from './MegaMenuTopNavigation.vue';
 import Logo from '../logo/Logo.vue';
 
+import {
+  KEYCODE_TAB,
+  KEYCODE_ENTER,
+  KEYCODE_ESC,
+  KEYCODE_SPACE,
+  KEYCODE_LEFT,
+  KEYCODE_UP,
+  KEYCODE_RIGHT,
+  KEYCODE_DOWN,
+} from '../../constants/keycodes';
+
 export default {
   components: {
     SvgIcon,
@@ -388,10 +399,10 @@ export default {
       if (this.isMobile) return;
 
       // Allow tab to pass through
-      if (e.keyCode !== 9) e.preventDefault();
+      if (e.keyCode !== KEYCODE_TAB) e.preventDefault();
 
       let cycle;
-      if (e.keyCode === 38 || e.keyCode === 40) {
+      if (e.keyCode === KEYCODE_UP || e.keyCode === KEYCODE_DOWN) {
         cycle = this.$refs.rootitems[this.current].querySelectorAll(
           '.menu__aside a,.menu__section a'
         );
@@ -399,7 +410,7 @@ export default {
 
       switch (e.keyCode) {
         // esc
-        case 27:
+        case KEYCODE_ESC:
           this.pointer = 0;
 
           // Set current menu item focus.
@@ -410,8 +421,8 @@ export default {
           // this.dismissBlanket();
           break;
         // enter / space
-        case 13:
-        case 32:
+        case KEYCODE_ENTER:
+        case KEYCODE_SPACE:
           if (e.target.classList.contains('.menu__item')) {
             e.target.querySelector('.menu__link').click();
           } else {
@@ -419,15 +430,15 @@ export default {
           }
           break;
         // left
-        case 37:
+        case KEYCODE_LEFT:
           this.prevRootItem();
           break;
         // right
-        case 39:
+        case KEYCODE_RIGHT:
           this.nextRootItem();
           break;
         // up
-        case 38:
+        case KEYCODE_UP:
           if (cycle.length > 1) {
             this.pointer = this.pointer > 0 ? this.pointer - 1 : cycle.length - 1;
             cycle[this.pointer].focus();
@@ -436,7 +447,7 @@ export default {
           }
           break;
         // down
-        case 40:
+        case KEYCODE_DOWN:
           if (cycle.length > 1) {
             this.pointer = this.pointer < cycle.length - 1 ? this.pointer + 1 : 0;
             cycle[this.pointer].focus();

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -306,13 +306,7 @@ export default {
         this.lastIndex = rootindex;
       }
 
-      if (
-        // eslint-disable-next-line no-magic-numbers
-        rootindex !== -1
-        && this.items[rootindex].items !== undefined
-        && !this.isMobileOpen
-        && !this.isMobile
-      ) {
+      if (this.items[rootindex].items !== undefined && !this.isMobileOpen && !this.isMobile) {
         this.activateBlanket(this.dismissDesktopMenu.bind(this));
         this.$refs.rootitems[rootindex].classList.add('menu__item--over');
         if (this.isAnimate) {

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -462,7 +462,7 @@ export default {
         // up
         case KEYCODE_UP:
           if (cycle.length > 1) {
-            this.pointer = this.pointer > 0 ? this.pointer - 1 : cycle.length - 1;
+            this.pointer = this.pointer >= 1 ? this.pointer - 1 : cycle.length - 1;
             cycle[this.pointer].focus();
           } else {
             // this.prevRootItem();
@@ -470,8 +470,10 @@ export default {
           break;
         // down
         case KEYCODE_DOWN:
+          const cycleStartIndex = 0;
+
           if (cycle.length > 1) {
-            this.pointer = this.pointer < cycle.length - 1 ? this.pointer + 1 : 0;
+            this.pointer = this.pointer < cycle.length - 1 ? this.pointer + 1 : cycleStartIndex;
             cycle[this.pointer].focus();
           } else {
             // this.nextRootItem();
@@ -483,7 +485,7 @@ export default {
     },
     prevRootItem() {
       this.pointer = 0;
-      this.current = this.current > 0 ? this.current - 1 : this.items.length - 1;
+      this.current = this.current >= 1 ? this.current - 1 : this.items.length - 1;
       this.dismissAllDesktopChildren();
       this.$refs.rootitems[this.current].focus();
       if (this.items[this.current].items) {
@@ -493,8 +495,10 @@ export default {
       }
     },
     nextRootItem() {
+      const itemsStartIndex = 0;
+
       this.pointer = 0;
-      this.current = this.current < this.items.length - 1 ? this.current + 1 : 0;
+      this.current = this.current < this.items.length - 1 ? this.current + 1 : itemsStartIndex;
       this.dismissAllDesktopChildren();
       this.$refs.rootitems[this.current].focus();
       if (this.items[this.current].items) {
@@ -502,10 +506,6 @@ export default {
       } else {
         this.dismissBlanket();
       }
-    },
-    isSelected(index) {
-      // eslint-disable-next-line no-magic-numbers
-      return index === this.current ? 0 : -1;
     },
   },
 };

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -299,6 +299,7 @@ export default {
       }
 
       if (
+        // eslint-disable-next-line no-magic-numbers
         rootindex !== -1
         && this.items[rootindex].items !== undefined
         && !this.isMobileOpen
@@ -485,6 +486,7 @@ export default {
       }
     },
     isSelected(index) {
+      // eslint-disable-next-line no-magic-numbers
       return index === this.current ? 0 : -1;
     },
   },

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -185,6 +185,7 @@ import PageSearchForm from '../search/PageSearchForm.vue';
 import MegaMenuTitle from './MegaMenuTitle.vue';
 import MegaMenuTopNavigation from './MegaMenuTopNavigation.vue';
 import Logo from '../logo/Logo.vue';
+import { WIDTH_900 } from '../../helpers/viewports';
 
 import {
   KEYCODE_TAB,
@@ -249,7 +250,7 @@ export default {
   computed: {
     isMobile() {
       return this.$refs.headerroot
-        ? this.$refs.headerroot.offsetWidth < 900
+        ? this.$refs.headerroot.offsetWidth < WIDTH_900
         : false;
     },
     isShowTopMenu() {
@@ -372,7 +373,7 @@ export default {
     openInner(e) {
       if (
         this.$refs.headerroot
-        && this.$refs.headerroot.offsetWidth < 900
+        && this.$refs.headerroot.offsetWidth < WIDTH_900
         && e.target.nextElementSibling
       ) {
         e.preventDefault();

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -263,8 +263,10 @@ export default {
   },
   methods: {
     isColColumns(rootindex) {
+      const oneColumnMaxLength = 5;
+
       if (this.isMobileOpen) return '';
-      if (this.items[rootindex].items.length <= 5) {
+      if (this.items[rootindex].items.length <= oneColumnMaxLength) {
         return 'cols-1';
       }
       return 'cols-2';

--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -118,15 +118,17 @@ export default {
     inputTrap(e) {
       // Get the index of the current active element within the modal
       const focusedIndex = this.focusableElements.indexOf(document.activeElement);
+      const lastElement = [...this.focusableElements].pop();
 
       // First element is focused and shiftkey is in use
       // eslint-disable-next-line no-magic-numbers
       if (e.shiftKey && (focusedIndex === 0 || focusedIndex === -1)) {
         // Loop back to last el
-        this.focusableElements[this.focusableElements.length - 1].focus();
+        lastElement.focus();
         e.preventDefault();
 
       // Last element is focused and shiftkey is not in use
+      // eslint-disable-next-line no-magic-numbers
       } else if (!e.shiftKey && focusedIndex === this.focusableElements.length - 1) {
         // Focus on first el
         this.focusableElements[0].focus();

--- a/components/modal/ModalDialog.vue
+++ b/components/modal/ModalDialog.vue
@@ -83,7 +83,7 @@ export default {
 
       // Show container and focus the modal
       container.setAttribute('aria-hidden', false);
-      modal.setAttribute('tabindex', -1);
+      modal.setAttribute('tabindex', '-1');
 
       // Focus first element if exists, otherwise focus modal element
       if (this.focusableElements.length) {
@@ -118,6 +118,7 @@ export default {
       const focusedIndex = this.focusableElements.indexOf(document.activeElement);
 
       // First element is focused and shiftkey is in use
+      // eslint-disable-next-line no-magic-numbers
       if (e.shiftKey && (focusedIndex === 0 || focusedIndex === -1)) {
         // Loop back to last el
         this.focusableElements[this.focusableElements.length - 1].focus();

--- a/components/nav/PageNav.vue
+++ b/components/nav/PageNav.vue
@@ -182,7 +182,7 @@ export default {
       evt.preventDefault();
 
       // Retrieve parent panel (i.e. the panel that was last opened)
-      const parent = this.state.open[this.state.open.length - 1];
+      const parent = [...this.state.open].pop();
 
       // Hide parent sidebar (and scroll back to top to work around nested absolute positioning)
       parent.classList.add('sitenav__panel--nested-open');
@@ -205,7 +205,7 @@ export default {
       panel.scrollTop = 0;
 
       // Show parent sidebar (i.e. vertical overflow)
-      const parent = this.state.open[this.state.open.length - 1];
+      const parent = [...this.state.open].pop();
       parent.classList.remove('sitenav__panel--nested-open');
       this.$emit('page-nav-close-nested-panel');
     },

--- a/components/navigation/InPageNavigation.vue
+++ b/components/navigation/InPageNavigation.vue
@@ -171,7 +171,7 @@ export default {
       this.sections.forEach((item) => {
         const elem = document.querySelector(`#${item.id}`);
         const offset = parseInt(elem.getBoundingClientRect().top, 10);
-        const scrollOffset = this.$refs.dropdown.getBoundingClientRect().height; // Add one pixel so it triggers the change
+        const scrollOffset = this.$refs.dropdown.getBoundingClientRect().height;
 
         if (offset <= scrollOffset) {
           selectedItem = item;

--- a/components/navigation/InPageNavigation.vue
+++ b/components/navigation/InPageNavigation.vue
@@ -58,7 +58,7 @@ export default {
     headingLevel: {
       type: String,
       required: true,
-      validator: (value) => ['h1', 'h2', 'h3', 'h4', 'h5'].indexOf(value) > -1,
+      validator: (value) => ['h1', 'h2', 'h3', 'h4', 'h5'].includes(value),
     },
     color: {
       type: String,

--- a/components/navigation/InPageNavigation.vue
+++ b/components/navigation/InPageNavigation.vue
@@ -46,6 +46,7 @@ import smoothscroll from 'smoothscroll-polyfill';
 import FocusWrapper from '../focus-wrapper/FocusWrapper.vue';
 import Dropdown from '../dropdown/Dropdown.vue';
 import SvgIcon from '../icons/SvgIcon.vue';
+import { WIDTH_481 } from '../../helpers/viewports';
 
 export default {
   components: { FocusWrapper, Dropdown, SvgIcon },
@@ -181,7 +182,7 @@ export default {
     },
     getWindowWidth() {
       this.windowWidth = document.documentElement.clientWidth;
-      if (this.windowWidth < 481) {
+      if (this.windowWidth < WIDTH_481) {
         this.size = 'small';
       } else {
         this.size = 'medium';

--- a/components/navigation/InPageNavigation.vue
+++ b/components/navigation/InPageNavigation.vue
@@ -136,7 +136,7 @@ export default {
       const inPageNavOffset = this.$refs.inPageNavigation.getBoundingClientRect();
       const elementToChange = this.sections[0];
 
-      if (this.sections.length >= 1) {
+      if (this.sections.length) {
         return (
           document.getElementById(elementToChange.id).getBoundingClientRect()
             .top < Math.abs(inPageNavOffset.top)
@@ -170,10 +170,10 @@ export default {
 
       this.sections.forEach((item) => {
         const elem = document.getElementById(item.id);
-        const offset = elem.getBoundingClientRect();
-        const scrollOffset = this.$refs.dropdown.getBoundingClientRect().height + 1; // Add one pixel so it triggers the change
+        const offset = parseInt(elem.getBoundingClientRect().top, 10);
+        const scrollOffset = this.$refs.dropdown.getBoundingClientRect().height; // Add one pixel so it triggers the change
 
-        if (offset.top < scrollOffset) {
+        if (offset <= scrollOffset) {
           selectedItem = item;
         }
       });

--- a/components/profiles/alumni-profiles/AlumniProfiles.vue
+++ b/components/profiles/alumni-profiles/AlumniProfiles.vue
@@ -32,6 +32,7 @@
 
 import FocusWrapper from '../../focus-wrapper/FocusWrapper.vue';
 import { IMAGE_PLACEHOLDER_BIG } from '../../../utils/placeholders';
+import { WIDTH_599 } from '../../helpers/viewports';
 
 export default {
   name: 'AlumniProfiles',
@@ -73,7 +74,7 @@ export default {
   methods: {
     getWindowWidth() {
       this.windowWidth = document.documentElement.clientWidth;
-      if (this.windowWidth < 599) {
+      if (this.windowWidth < WIDTH_599) {
         this.size = 'small';
       } else {
         this.size = 'large';

--- a/components/profiles/alumni-profiles/AlumniProfiles.vue
+++ b/components/profiles/alumni-profiles/AlumniProfiles.vue
@@ -32,7 +32,7 @@
 
 import FocusWrapper from '../../focus-wrapper/FocusWrapper.vue';
 import { IMAGE_PLACEHOLDER_BIG } from '../../../utils/placeholders';
-import { WIDTH_599 } from '../../helpers/viewports';
+import { WIDTH_599 } from '../../../helpers/viewports';
 
 export default {
   name: 'AlumniProfiles',

--- a/components/quick-links-menu/QuickLinks.vue
+++ b/components/quick-links-menu/QuickLinks.vue
@@ -9,7 +9,7 @@
     <div class="cell cell--desk-2of3 ql-menu__content">
       <slot name="content" />
       <div
-        v-if="secondaryLinks && secondaryLinks.length "
+        v-if="secondaryLinks && secondaryLinks.length"
         :class="{ [`ql-menu__secondary--2col`]: secondaryCols === 2 }"
         class="ql-menu__secondary">
         <QuickLinksSecondaryItem

--- a/components/quick-links-menu/QuickLinks.vue
+++ b/components/quick-links-menu/QuickLinks.vue
@@ -9,7 +9,7 @@
     <div class="cell cell--desk-2of3 ql-menu__content">
       <slot name="content" />
       <div
-        v-if="secondaryLinks && secondaryLinks.length > 0"
+        v-if="secondaryLinks && secondaryLinks.length "
         :class="{ [`ql-menu__secondary--2col`]: secondaryCols === 2 }"
         class="ql-menu__secondary">
         <QuickLinksSecondaryItem
@@ -23,7 +23,7 @@
     </div>
     <div class="cell cell--desk-1of3">
       <nav
-        v-if="menuLinks.length > 0"
+        v-if="menuLinks.length"
         class="ql-menu__nav">
         <slot name="menu-header" />
         <QuickLinksMenuItem

--- a/components/search/PageSearch.vue
+++ b/components/search/PageSearch.vue
@@ -37,6 +37,8 @@ import SvgIcon from '../icons/SvgIcon.vue';
 import Blanket from './blanket';
 import PageSearchForm from './PageSearchForm.vue';
 
+import { KEYCODE_ESC } from '../../constants/keycodes';
+
 export default {
   name: 'PageSearch',
   components: { SvgIcon, PageSearchForm },
@@ -61,7 +63,7 @@ export default {
       this.$emit('page-search-close');
     },
     esc(e) {
-      if (e.keyCode === 27) this.close();
+      if (e.keyCode === KEYCODE_ESC) this.close();
     },
   },
 };

--- a/components/section/SectionDivider.vue
+++ b/components/section/SectionDivider.vue
@@ -6,7 +6,7 @@
       <h3 class="heading-section">
         {{ title }}
       </h3>
-      <p v-if="subtitle && subtitle.length > 0">
+      <p v-if="subtitle && subtitle.length">
         {{ subtitle }}
       </p>
     </div>

--- a/components/section/SectionWrap.vue
+++ b/components/section/SectionWrap.vue
@@ -64,7 +64,7 @@ export default {
       return {
         [`bg-${this.bgColor}`]: !!this.bgColor,
         'section--centred': this.centred,
-        'section--image': this.bgImage && this.bgImage.length > 0,
+        'section--image': this.bgImage && this.bgImage.length,
       };
     },
   },

--- a/components/sublink-menu/SublinkMenu.vue
+++ b/components/sublink-menu/SublinkMenu.vue
@@ -7,7 +7,7 @@
       height="100"
       class="sublink-menu__icon" />
     <img
-      v-if="img && img.length > 0"
+      v-if="img && img.length"
       :src="img"
       class="sublink-menu__image"
       alt="">

--- a/components/tables/CompactedTable.vue
+++ b/components/tables/CompactedTable.vue
@@ -27,22 +27,25 @@ export default {
   methods: {
     mobifyTable() {
       const headings = this.$refs.table.querySelectorAll('thead th');
+      const rows = this.$refs.table.querySelectorAll('tr:not(.table__header)');
       const mobileHeadingCell = 0;
 
       this.hasHeadings = this.$refs.table.querySelectorAll('.table__header').length;
 
-      for (let rows = this.$refs.table.querySelectorAll('tr:not(.table__header)'), i = rows.length - 1; i >= 0; i -= 1) {
-        for (let cells = rows[i].querySelectorAll('td'), j = cells.length - 1; j >= 0; j -= 1) {
+      rows.forEach((row, rowIndex) => {
+        const cells = rows[rowIndex].querySelectorAll('td');
+
+        cells.forEach((cell, cellIndex) => {
           if (!this.hasHeadings) {
             cells[mobileHeadingCell].classList.add('table__mobile-title');
-            rows[i].setAttribute('data-mobile-heading', (cells[mobileHeadingCell].textContent));
+            rows[rowIndex].setAttribute('data-mobile-heading', (cells[mobileHeadingCell].textContent));
           }
 
-          if (headings[j]) {
-            cells[j].setAttribute('data-label', (`${headings[j].textContent.trim()}:`));
+          if (headings[cellIndex]) {
+            cells[cellIndex].setAttribute('data-label', (`${headings[cellIndex].textContent.trim()}:`));
           }
-        }
-      }
+        });
+      });
     },
   },
 };

--- a/components/tables/CompactedTable.vue
+++ b/components/tables/CompactedTable.vue
@@ -29,7 +29,7 @@ export default {
       const headings = this.$refs.table.querySelectorAll('thead th');
       const mobileHeadingCell = 0;
 
-      this.hasHeadings = this.$refs.table.querySelectorAll('.table__header').length > 0;
+      this.hasHeadings = this.$refs.table.querySelectorAll('.table__header').length;
 
       for (let rows = this.$refs.table.querySelectorAll('tr:not(.table__header)'), i = rows.length - 1; i >= 0; i -= 1) {
         for (let cells = rows[i].querySelectorAll('td'), j = cells.length - 1; j >= 0; j -= 1) {

--- a/components/tables/ResponsiveTable.vue
+++ b/components/tables/ResponsiveTable.vue
@@ -12,6 +12,8 @@
 </template>
 
 <script>
+import { TIMER_50 } from '../../constants/timers';
+
 export default {
   data() {
     return {
@@ -43,7 +45,7 @@ export default {
         const tableWidth = this.$refs.table.querySelector('table').getBoundingClientRect().width;
 
         return tableWidth > containerWidth;
-      }, 50);
+      }, TIMER_50);
     },
     checkAtEndOfTable(elem) {
       const containerWidth = this.$refs.table.getBoundingClientRect().width;

--- a/components/tables/ResponsiveTable.vue
+++ b/components/tables/ResponsiveTable.vue
@@ -56,8 +56,9 @@ export default {
     },
     checkAtStartOfTable(elem) {
       const scrollLeftPosition = elem.target.scrollLeft;
+      const startLeftPosition = 0;
 
-      return scrollLeftPosition === 0;
+      return scrollLeftPosition === startLeftPosition;
     },
   },
 };

--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -229,15 +229,16 @@ export default {
     },
     calculateTabsWidth() {
       const { tabsList } = this.$refs;
+      const tabsWidthIntital = 0;
 
       if (tabsList !== undefined) {
         const tabs = this.$refs.tabsList.childNodes;
-        const tabsWidth = [...tabs].reduce((total, tab) => total + tab.clientWidth, 0);
+        const tabsWidth = [...tabs].reduce((total, tab) => total + tab.clientWidth, tabsWidthIntital);
 
         return tabsWidth;
       }
 
-      return 0;
+      return tabsWidthIntital;
     },
     selectActive(e) {
       const index = e.target.selectedIndex;
@@ -279,24 +280,27 @@ export default {
     getTabs() {
       // Only grab <Tab>
       const children = this.$children.filter((child) => child.title !== undefined);
+      const childrenActiveIndex = 0;
 
-      children.forEach((tab, i) => {
+      children.forEach((tab, index) => {
         tab.namespace = `ui-tab-${this._uid}`;
-        tab.index = i;
-        tab.isActive = i === 0;
+        tab.index = index;
+        tab.isActive = index === childrenActiveIndex;
       });
 
       return children;
     },
     getTabSiblings() {
       let curr = -1;
+      const startTabIndex = 0;
+
       this.$refs.tabs.forEach((tab, index) => {
         if (tab.getAttribute('tabindex') === '0') {
           curr = index;
         }
       }, this);
 
-      const prev = curr - 1 < 0 ? 0 : curr - 1;
+      const prev = curr - 1 < startTabIndex ? startTabIndex : curr - 1;
       const next = curr + 1 > this.$refs.tabs.length - 1 ? this.$refs.tabs.length - 1 : curr + 1;
 
       return {
@@ -306,9 +310,10 @@ export default {
     },
     moveToTab(toTab) {
       const { length } = this.$refs.tabs;
+      const startTabIndex = 0;
 
       this.edgeNext = this.checkControlIsDisabled(toTab, length - 1);
-      this.edgePrev = this.checkControlIsDisabled(toTab, 0);
+      this.edgePrev = this.checkControlIsDisabled(toTab, startTabIndex);
 
       this.setActive(toTab);
       this.scrollTo(toTab);

--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -85,6 +85,10 @@ import { throttle } from 'throttle-debounce';
 import StyledSelect from '../forms/StyledSelect.vue';
 import SvgIcon from '../icons/SvgIcon.vue';
 
+import {
+  KEYCODE_LEFT, KEYCODE_UP, KEYCODE_RIGHT, KEYCODE_DOWN,
+} from '../../constants/keycodes';
+
 export default {
   components: {
     StyledSelect,
@@ -255,13 +259,13 @@ export default {
 
       switch (e.keyCode) {
         // left / up
-        case 37:
-        case 38:
+        case KEYCODE_LEFT:
+        case KEYCODE_UP:
           this.moveToTab(prev);
           break;
         // right / down
-        case 39:
-        case 40:
+        case KEYCODE_RIGHT:
+        case KEYCODE_DOWN:
           this.moveToTab(next);
           break;
         default:

--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -89,6 +89,8 @@ import {
   KEYCODE_LEFT, KEYCODE_UP, KEYCODE_RIGHT, KEYCODE_DOWN,
 } from '../../constants/keycodes';
 
+import { TIMER_100, TIMER_2000 } from '../../constants/timers';
+
 export default {
   components: {
     StyledSelect,
@@ -185,14 +187,14 @@ export default {
       setTimeout(() => {
         this.tabsWidth = this.calculateTabsWidth();
         this.showControls = this.hasControls();
-      }, 2000);
+      }, TIMER_2000);
     },
   },
   mounted() {
     this.panels = this.getTabs();
     this.showSelect = this.selectOptions.length > 1;
 
-    this.throttledTabsScrollEvent = throttle(100, this.checkControls);
+    this.throttledTabsScrollEvent = throttle(TIMER_100, this.checkControls);
     window.addEventListener('resize', this.throttledTabsScrollEvent);
   },
   beforeDestroy() {

--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -120,7 +120,7 @@ export default {
     color: {
       type: String,
       default: '',
-      validator: (color) => ['', 'navy', 'teal', 'yellow'].indexOf(color) > -1,
+      validator: (color) => ['', 'navy', 'teal', 'yellow'].includes(color),
     },
   },
   data: () => ({

--- a/components/testimonials/Testimonials.vue
+++ b/components/testimonials/Testimonials.vue
@@ -32,6 +32,7 @@ import FocusWrapper from '../focus-wrapper/FocusWrapper.vue';
 import { IMAGE_PLACEHOLDER_BIG } from '../../utils/placeholders';
 import ContentBlock from '../content-block/ContentBlock.vue';
 import BlockQuotation from '../block-quotation/BlockQuotation.vue';
+import { WIDTH_599 } from '../../helpers/viewports';
 
 export default {
   name: 'Testimonials',
@@ -85,7 +86,7 @@ export default {
   methods: {
     getWindowWidth() {
       this.windowWidth = document.documentElement.clientWidth;
-      if (this.windowWidth < 599) {
+      if (this.windowWidth < WIDTH_599) {
         this.size = 'small';
       } else {
         this.size = 'large';

--- a/components/toggle/ToggleBlock.vue
+++ b/components/toggle/ToggleBlock.vue
@@ -34,6 +34,10 @@
 
 import focusableElements from '../../utils/focusable-elements';
 
+import {
+  KEYCODE_TAB, KEYCODE_ENTER, KEYCODE_ESC, KEYCODE_SPACE,
+} from '../../constants/keycodes';
+
 export default {
   name: 'ToggleBlock',
   props: {
@@ -104,16 +108,16 @@ export default {
       if (e.metaKey || e.altKey) return;
 
       // Allow tab to pass through
-      if (e.keyCode !== 9) e.preventDefault();
+      if (e.keyCode !== KEYCODE_TAB) e.preventDefault();
 
       switch (e.keyCode) {
         // esc
-        case 27:
+        case KEYCODE_ESC:
           this.isActive = false;
           break;
         // enter / space
-        case 13:
-        case 32:
+        case KEYCODE_ENTER:
+        case KEYCODE_SPACE:
           this.toggle();
           break;
         default: break;

--- a/components/toggle/ToggleBlock.vue
+++ b/components/toggle/ToggleBlock.vue
@@ -100,7 +100,7 @@ export default {
     getActive() { return this.isActive; },
     toggleFocusableElements() {
       this.focusableElements.forEach((el) => {
-        el.setAttribute('tabindex', this.isActive ? 0 : -1);
+        el.setAttribute('tabindex', this.isActive ? '0' : '-1');
       });
     },
     handleKey(e) {

--- a/components/toggle/ToggleGroup.vue
+++ b/components/toggle/ToggleGroup.vue
@@ -11,6 +11,21 @@
 // toggle-group-hide-panel
 // toggle-group-show-current-panel
 
+import {
+  KEYCODE_TAB,
+  KEYCODE_ENTER,
+  KEYCODE_ESC,
+  KEYCODE_SPACE,
+  KEYCODE_PGDN,
+  KEYCODE_PGUP,
+  KEYCODE_END,
+  KEYCODE_HOME,
+  KEYCODE_LEFT,
+  KEYCODE_UP,
+  KEYCODE_RIGHT,
+  KEYCODE_DOWN,
+} from '../../constants/keycodes';
+
 export default {
   name: 'ToggleGroup',
   props: {
@@ -96,46 +111,46 @@ export default {
       if (e.metaKey || e.altKey) return;
 
       // Allow tab to pass through
-      if (e.keyCode !== 9) e.preventDefault();
+      if (e.keyCode !== KEYCODE_TAB) e.preventDefault();
 
       this.getCurrent(e);
 
       switch (e.keyCode) {
         // esc
-        case 27:
+        case KEYCODE_ESC:
           this.hidePanel(this.current);
           break;
         // enter / space
-        case 13:
-        case 32:
+        case KEYCODE_ENTER:
+        case KEYCODE_SPACE:
           this.togglePanel(e);
           break;
         // ctrl + pgdn
-        case 34:
+        case KEYCODE_PGDN:
           if (e.ctrlKey) this.nextPanel();
           break;
         // ctrl + pgup
-        case 33:
+        case KEYCODE_PGUP:
           if (e.ctrlKey) ;
           break;
         // end
-        case 35:
+        case KEYCODE_END:
           this.current = this.panels.length - 1;
           this.giveHeaderFocus();
           break;
         // home
-        case 36:
+        case KEYCODE_HOME:
           this.current = 0;
           this.giveHeaderFocus();
           break;
         // left / up
-        case 37:
-        case 38:
+        case KEYCODE_LEFT:
+        case KEYCODE_UP:
           this.previousPanel();
           break;
         // right / down
-        case 39:
-        case 40:
+        case KEYCODE_RIGHT:
+        case KEYCODE_DOWN:
           this.nextPanel();
           break;
         default:

--- a/components/toggle/ToggleGroup.vue
+++ b/components/toggle/ToggleGroup.vue
@@ -170,11 +170,15 @@ export default {
       }
     },
     previousPanel() {
-      this.current = this.current - 1 < 0 ? this.panels.length - 1 : this.current - 1;
+      const startPanelIndex = 0;
+
+      this.current = this.current - 1 < startPanelIndex ? this.panels.length - 1 : this.current - 1;
       this.giveHeaderFocus();
     },
     nextPanel() {
-      this.current = this.current + 1 > this.panels.length - 1 ? 0 : this.current + 1;
+      const startPanelIndex = 0;
+
+      this.current = this.current + 1 > this.panels.length - 1 ? startPanelIndex : this.current + 1;
       this.giveHeaderFocus();
     },
     giveHeaderFocus() {

--- a/components/toggle/ToggleGroup.vue
+++ b/components/toggle/ToggleGroup.vue
@@ -168,10 +168,10 @@ export default {
     giveHeaderFocus() {
       // remove focusability from inactives
       this.panels.forEach((panel) => {
-        panel.header().setAttribute('tabindex', -1);
+        panel.header().setAttribute('tabindex', '-1');
       });
       // set active focus
-      this.panels[this.current].header().setAttribute('tabindex', 0);
+      this.panels[this.current].header().setAttribute('tabindex', '0');
       this.panels[this.current].header().focus();
     },
   },

--- a/components/welcome/Welcome.vue
+++ b/components/welcome/Welcome.vue
@@ -10,12 +10,12 @@
         </figcaption>
       </figure>
       <p
-        v-if="captionText && captionText.length > 0"
+        v-if="captionText && captionText.length"
         class="welcome__caption-text">
         {{ captionText }}
       </p>
       <ButtonIcon
-        v-if="btnText && btnText.length > 0"
+        v-if="btnText && btnText.length"
         icon="chevron-right"
         class="btn--xsml">
         {{ btnText }}

--- a/constants/keycodes.js
+++ b/constants/keycodes.js
@@ -1,0 +1,12 @@
+export const KEYCODE_TAB = 9;
+export const KEYCODE_ENTER = 13;
+export const KEYCODE_ESC = 27;
+export const KEYCODE_SPACE = 32;
+export const KEYCODE_PGUP = 33;
+export const KEYCODE_PGDN = 34;
+export const KEYCODE_END = 35;
+export const KEYCODE_HOME = 36;
+export const KEYCODE_LEFT = 37;
+export const KEYCODE_UP = 38;
+export const KEYCODE_RIGHT = 39;
+export const KEYCODE_DOWN = 40;

--- a/constants/timers.js
+++ b/constants/timers.js
@@ -1,0 +1,15 @@
+const TIMER_50 = 50;
+const TIMER_100 = 100;
+const TIMER_200 = 200;
+const TIMER_1100 = 1100;
+const TIMER_2000 = 2000;
+const TIMER_90000 = 90000;
+
+module.exports = {
+  TIMER_50,
+  TIMER_100,
+  TIMER_200,
+  TIMER_1100,
+  TIMER_2000,
+  TIMER_90000,
+};

--- a/helpers/viewports.js
+++ b/helpers/viewports.js
@@ -1,0 +1,3 @@
+export const WIDTH_481 = 481;
+export const WIDTH_599 = 599;
+export const WIDTH_900 = 900;

--- a/snapshots/setupTests.js
+++ b/snapshots/setupTests.js
@@ -1,4 +1,5 @@
 const { configureToMatchImageSnapshot } = require('jest-image-snapshot');
+const { TIMER_90000 } = require('../constants/timers');
 
 const toMatchImageSnapshot = configureToMatchImageSnapshot({
   customDiffConfig: { threshold: 0.5 },
@@ -8,4 +9,4 @@ const toMatchImageSnapshot = configureToMatchImageSnapshot({
 
 expect.extend({ toMatchImageSnapshot });
 
-jest.setTimeout(90000);
+jest.setTimeout(TIMER_90000);


### PR DESCRIPTION
This PR aims to improve the readability of the code base by restricting the use of `magic numbers` where possible.

- set `"ignore": [1]` as it is quite common to test for `.length >= 1` & `.length -1` etc
- Any use of magic numbers should be assigned to a descriptive variable name that explains what it is doing.
- Created some CONSTANTS for keycodes and timers.
- removed deprecated `isSelected(index)` from `MegaMenu.vue` to resolve linting issue
- disabled some linting errors in `ModalDialog.vue` as that funciton isn't fired and can't be tested easily. #1427