### PR TITLE
using aria-label instead of aria-labelledby

### DIFF
--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -159,7 +159,7 @@
             class="link-icon__icon svg"
             role="presentation"
             focusable="false"
-            aria-labelledby="icon-menu"
+            aria-label="icon menu"
             viewBox="10 10 26 28">
             <path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z" />
           </svg>


### PR DESCRIPTION
# Description

Aria-labelledby attribute must point to IDs of elements in the same document.

This is similar to this issue:unimelb/find-a-course#1842
However the element with the ID does exist.

I suspect that this issue is caused by the incorrect use of aria-labelledby.

Fixes #1450

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11