### PR TITLE
fix(filters): dropdown role

### DIFF
--- a/components/filters/components/filter-dropdown/FilterDropdown.vue
+++ b/components/filters/components/filter-dropdown/FilterDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    role="combobox"
+    role="region"
     class="filter-dropdown"
     :data-uuid="uuid"
     @keydown.esc="closeOnKeypress"

--- a/components/filters/components/filter-dropdown/__tests__/__snapshots__/FilterDropdown.test.js.snap
+++ b/components/filters/components/filter-dropdown/__tests__/__snapshots__/FilterDropdown.test.js.snap
@@ -4,7 +4,7 @@ exports[`FilterDropdown should match spapshot 1`] = `
 <div
   class="filter-dropdown"
   data-uuid="0"
-  role="combobox"
+  role="region"
 >
   <div
     aria-expanded="false"


### PR DESCRIPTION
# Description

Fix accessibility role for the dropdown in the filters

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Make sure to do not repeat yourself (DRY)
- [x] Snapshots tested
- [x] A11y tested
- [x] CSS utilises BEM naming convention and structure
- [x] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [x] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11