### PR TITLE
feat(component): header text with cta 2 column

### DIFF
--- a/components/_vars.css
+++ b/components/_vars.css
@@ -122,7 +122,6 @@
   --fw-normal: 500;
   --fw-light: 300;
   --fw-regular: 400;
-  --fw-normal: 500;
 
   /* Border radius */
   --br: 4px;

--- a/components/section/SectionTwoCol.vue
+++ b/components/section/SectionTwoCol.vue
@@ -16,6 +16,14 @@
         <slot name="main" />
       </ListItem>
     </ListingWrap>
+    <ListingWrap v-if="direction === 'split'">
+      <ListItem cols="1of2">
+        <slot name="left" />
+      </ListItem>
+      <ListItem cols="2of2">
+        <slot name="right" />
+      </ListItem>
+    </ListingWrap>
   </SectionWrap>
 </template>
 

--- a/components/section/SectionTwoCol.vue
+++ b/components/section/SectionTwoCol.vue
@@ -16,14 +16,6 @@
         <slot name="main" />
       </ListItem>
     </ListingWrap>
-    <ListingWrap v-if="direction === 'split'">
-      <ListItem cols="1of2">
-        <slot name="left" />
-      </ListItem>
-      <ListItem cols="2of2">
-        <slot name="right" />
-      </ListItem>
-    </ListingWrap>
   </SectionWrap>
 </template>
 

--- a/components/section/_two-column-header-text.css
+++ b/components/section/_two-column-header-text.css
@@ -2,6 +2,37 @@
  * Two columns with cta
  */
 .two-column-header-text {
+
+  .grid {
+    @media (--bp-tablet) {
+      flex-flow: row;
+    }
+  }
+
+  &__first-column {
+    margin: 0;
+
+    @media (--bp-tablet) {
+      padding-right: 2rem;
+    }
+
+    @media (--bp-desktop) {
+      padding-right: 4rem;
+    }
+  }
+
+  &__second-column {
+    margin: 0;
+
+    @media (--bp-tablet) {
+      padding-left: 2rem;
+    }
+
+    @media (--bp-desktop) {
+      padding-left: 4rem;
+    }
+  }
+
   &__heading {
     font-family: var(--ff-lead);
     font-weight: var(--fw-bold);

--- a/components/section/_two-column-header-text.css
+++ b/components/section/_two-column-header-text.css
@@ -1,0 +1,23 @@
+/**
+ * Two columns with cta
+ */
+.two-column-header-text {
+  &__heading {
+    font-family: var(--ff-lead);
+    font-weight: var(--fw-bold);
+    font-size: 2.5rem;
+    line-height: 1.2;
+    letter-spacing: -.025rem;
+    color: rgb(var(--col-grey-mid-3));
+    margin-bottom: .5rem;
+  }
+
+  &__description {
+    font-weight: var(--fw-normal);
+    font-size: 1.125rem;
+    line-height: 1.67;
+    letter-spacing: -.021rem;
+    color: rgb(var(--col-grey-mid-3));
+    margin-bottom: 1.875rem;
+  }
+}

--- a/components/section/_two-column-header-text.css
+++ b/components/section/_two-column-header-text.css
@@ -2,9 +2,8 @@
  * Two columns with cta
  */
 .two-column-header-text {
-
   .grid {
-    @media (--bp-tablet) {
+    @media (--bp-x-tablet) {
       flex-flow: row;
     }
   }
@@ -12,7 +11,7 @@
   &__first-column {
     margin: 0;
 
-    @media (--bp-tablet) {
+    @media (--bp-x-tablet) {
       padding-right: 2rem;
     }
 
@@ -24,31 +23,43 @@
   &__second-column {
     margin: 0;
 
-    @media (--bp-tablet) {
-      padding-left: 2rem;
-    }
-
     @media (--bp-desktop) {
       padding-left: 4rem;
     }
   }
 
   &__heading {
+    font-size: 1.25rem;
+    line-height: 1.3;
     font-family: var(--ff-lead);
     font-weight: var(--fw-bold);
-    font-size: 2.5rem;
-    line-height: 1.2;
     letter-spacing: -.025rem;
     color: rgb(var(--col-grey-mid-3));
-    margin-bottom: .5rem;
+    margin-bottom: 1.25rem;
+
+    @media (--bp-x-tablet) {
+      font-size: 1.5rem;
+      line-height: 1.4;
+    }
+
+    @media (--bp-desktop) {
+      font-size: 2.5rem;
+      line-height: 1.2;
+      margin-bottom: .5rem;
+    }
   }
 
   &__description {
+    font-size: 1rem;
+    line-height: 1.63;
     font-weight: var(--fw-normal);
-    font-size: 1.125rem;
-    line-height: 1.67;
     letter-spacing: -.021rem;
     color: rgb(var(--col-grey-mid-3));
     margin-bottom: 1.875rem;
+
+    @media (--bp-x-tablet) {
+      font-size: 1.125rem;
+      line-height: 1.67;
+    }
   }
 }

--- a/components/section/index.css
+++ b/components/section/index.css
@@ -1,3 +1,4 @@
 @import '_section.css';
 @import '_split-section.css';
 @import '_two-column-round-image.css';
+@import '_two-column-header-text.css';

--- a/components/section/stories/SectionTwo/Story6.vue
+++ b/components/section/stories/SectionTwo/Story6.vue
@@ -1,12 +1,16 @@
 <template>
   <SectionWrap class="two-column-header-text">
     <div class="grid grid--center">
-      <ListItem cols="1of2">
+      <ListItem
+        class="two-column-header-text__first-column"
+        cols="1of2">
         <h3 class="two-column-header-text__heading">
           Discover engineering at Melbourne
         </h3>
       </ListItem>
-      <ListItem cols="1of2">
+      <ListItem
+        class="two-column-header-text__second-column"
+        cols="1of2">
         <p class="two-column-header-text__description">
           Anim mollit ut eu amet ipsum eu incididunt voluptate commodo mollit Lorem Lorem dolor. Commodo nisi pariatur proident quis eu excepteur magna. Culpa sit ut eu labore voluptate.
         </p>

--- a/components/section/stories/SectionTwo/Story6.vue
+++ b/components/section/stories/SectionTwo/Story6.vue
@@ -1,0 +1,30 @@
+<template>
+  <SectionWrap class="two-column-header-text">
+    <div class="grid grid--center">
+      <ListItem cols="1of2">
+        <h3 class="two-column-header-text__heading">
+          Discover engineering at Melbourne
+        </h3>
+      </ListItem>
+      <ListItem cols="1of2">
+        <p class="two-column-header-text__description">
+          Anim mollit ut eu amet ipsum eu incididunt voluptate commodo mollit Lorem Lorem dolor. Commodo nisi pariatur proident quis eu excepteur magna. Culpa sit ut eu labore voluptate.
+        </p>
+        <button-icon
+          href="www.google.com"
+          class="btn--cta">
+          I am a button
+        </button-icon>
+      </ListItem>
+    </div>
+  </SectionWrap>
+</template>
+
+<script>
+import SectionWrap from '../../SectionWrap.vue';
+
+export default {
+  components: { SectionWrap },
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/section/stories/SectionTwo/index.js
+++ b/components/section/stories/SectionTwo/index.js
@@ -6,14 +6,16 @@ import Story2 from './Story2.vue';
 import Story3 from './Story3.vue';
 import Story4 from './Story4.vue';
 import Story5 from './Story5.vue';
+import Story6 from './Story6.vue';
 /* ##Import story component here */
 
 /* Section - Focus  */
 storiesOf('Section/Two Column', module)
   .add('Left', createStory(Story1))
   .add('Right', createStory(Story2))
-  .add('Right with round image', createStory(Story5))
   .add('In small section', createStory(Story3))
-  .add('With text in sidebar', createStory(Story4));
+  .add('With text in sidebar', createStory(Story4))
+  .add('Right with round image', createStory(Story5))
+  .add('Header text with cta button', createStory(Story6));
 
 /* ##Story goes here */


### PR DESCRIPTION
# Description

Fixes
https://jira.unimelb.edu.au/browse/VOD-109
https://jira.unimelb.edu.au/browse/VOD-128

preview:

[header text with cta](https://deploy-preview-1469--pattern-lib-unimelb.netlify.app/?selectedKind=Section%2FTwo%20Column&selectedStory=Header%20text%20with%20cta%20button&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Make sure to do not repeat yourself (DRY)
- [x] Snapshots tested
- [x] A11y tested
- [x] CSS utilises BEM naming convention and structure
- [x] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [x] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11