### PR TITLE
fix(component): Screen Reader Jump To main content

### DIFF
--- a/components/buttons/ButtonIcon.vue
+++ b/components/buttons/ButtonIcon.vue
@@ -2,6 +2,8 @@
   <component
     :is="element"
     :class="classes"
+    :role="role"
+    :tab-index="tabIndex"
     :href="isLink && href"
     :aria-disabled="isLink && disabled ? 'true' : false"
     :disabled="!isLink && disabled">
@@ -75,6 +77,14 @@ export default {
     top: {
       type: Boolean,
       default: false,
+    },
+    role: {
+      type: String,
+      default: undefined,
+    },
+    tabIndex: {
+      type: Number,
+      default: undefined,
     },
   },
   computed: {

--- a/components/screen-reader-jump-to/ScreenReaderJumpTo.vue
+++ b/components/screen-reader-jump-to/ScreenReaderJumpTo.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="screen-reader-jump-to">
     <ButtonIcon
-      :href="toElement"
+      element="button"
+      role="link"
+      :tabindex="0"
       no-icon
       size="xsml"
       class="screen-reader-jump-to__skippy screenreaders-only screenreaders-only-focusable btn--inverted"
-      @click.prevent>
+      @click.native.prevent="scrollTo">
       {{ text }}
     </ButtonIcon>
   </div>
@@ -26,6 +28,15 @@ export default {
     toElement: {
       type: String,
       default: '#main',
+    },
+  },
+  methods: {
+    scrollTo() {
+      const toElement = document.querySelector(this.toElement);
+      if (toElement) {
+        toElement.scrollIntoView();
+        toElement.focus();
+      }
     },
   },
 };

--- a/components/screen-reader-jump-to/ScreenReaderJumpTo.vue
+++ b/components/screen-reader-jump-to/ScreenReaderJumpTo.vue
@@ -27,12 +27,12 @@ export default {
     },
     toElement: {
       type: String,
-      default: '#main',
+      default: 'main',
     },
   },
   methods: {
     scrollTo() {
-      const toElement = document.querySelector(this.toElement);
+      const toElement = document.querySelector(`[role="${this.toElement}"]`);
       if (toElement) {
         toElement.scrollIntoView();
         toElement.focus();

--- a/components/screen-reader-jump-to/index.css
+++ b/components/screen-reader-jump-to/index.css
@@ -1,6 +1,6 @@
 .screen-reader-jump-to {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   background-color: rgb(var(--col-background-primary-navy));
 
   &__skippy {

--- a/components/screen-reader-jump-to/stories/Default.vue
+++ b/components/screen-reader-jump-to/stories/Default.vue
@@ -2,7 +2,7 @@
   <div>
     <ScreenReaderJumpTo
       text="Skip to main content"
-      to-element="#main" />
+      to-element="main" />
     <MegaMenu
       :items="items"
       :top-menu="topMenu"
@@ -25,7 +25,7 @@
     </div>
 
     <div
-      id="main"
+      role="main"
       tabindex="-1">
       <section-wrap bg-color="white">
         <h1>Main content</h1>

--- a/components/screen-reader-jump-to/stories/Default.vue
+++ b/components/screen-reader-jump-to/stories/Default.vue
@@ -10,23 +10,36 @@
       faculty-name="Faculty of Medicine, Dentistry and Health Sciences"
       faculty-link="/faculty-link"
       faculty-width="25.5%" />
+
+    <div tabindex="-1">
+      <section-wrap bg-color="white">
+        <h2>Secondary content</h2>
+        <p
+          v-for="key in 20"
+          :key="key">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae
+          quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo
+          necessitatibus ut!
+        </p>
+      </section-wrap>
+    </div>
+
     <div
       id="main"
       tabindex="-1">
       <section-wrap bg-color="white">
         <h1>Main content</h1>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo necessitatibus ut!</p>
+        <button
+          tabindex="0">
+          Button
+        </button>
+        <p
+          v-for="key in 10"
+          :key="key">
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint explicabo quibusdam commodi quidem vitae
+          quaerat cumque, ex velit facilis. Minus ipsum quidem temporibus doloremque molestias doloribus delectus, nemo
+          necessitatibus ut!
+        </p>
       </section-wrap>
     </div>
   </div>
@@ -53,8 +66,7 @@ export default {
           href: '/',
           feature: {
             alt: 'screen reader only',
-            text:
-              'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            text: 'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             img: 'https://i.picsum.photos/id/1040/360/200.jpg',
             link: 'http://google.com',
           },
@@ -75,8 +87,7 @@ export default {
           href: '/why-melbourne',
           feature: {
             title: 'Campaign title',
-            text:
-              'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            text: 'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             img: 'https://i.picsum.photos/id/1033/360/200.jpg',
             link: 'http://google.com',
           },
@@ -93,15 +104,13 @@ export default {
           href: '/admissions',
           feature: {
             title: 'Different campaign',
-            text:
-              'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            text: 'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
           },
           items: [
             { title: 'Entry non requirements6', href: 'http://www.google.com' },
             { title: 'Entry non requirements7', href: 'http://www.google.com' },
             {
-              title:
-                'Entry non requirements8 has a particularly long title for no good reason',
+              title: 'Entry non requirements8 has a particularly long title for no good reason',
               href: 'http://www.google.com',
             },
             { title: 'Entry non requirements9', href: 'http://www.google.com' },
@@ -133,8 +142,7 @@ export default {
           href: '/student-experience',
           feature: {
             alt: 'screen reader only',
-            text:
-              'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            text: 'Study at the Conservatorium celebrates lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             img: 'https://i.picsum.photos/id/1040/360/200.jpg',
             link: 'http://google.com',
           },

--- a/components/screen-reader-jump-to/stories/screenReaderMd.md
+++ b/components/screen-reader-jump-to/stories/screenReaderMd.md
@@ -5,5 +5,12 @@
 > Screen readers will be able to skip to the main content instead of going and tabbing through the Mega Menu.
 
 ```html
-<screen-reader-jump-to text="Choose the text of the skip button" to-element="Choose where you wanna the button linked to eg: #main"></screen-reader-jump-to>
+<screen-reader-jump-to text="Choose the text of the skip button" to-element="main"></screen-reader-jump-to>
+```
+
+`to-element` property is optional, by default this component is looking for the element by the "main" role. You should add a `role="main"` attribute to the main content:
+```html
+<div role="main">
+  Content
+</div>
 ```


### PR DESCRIPTION
These changes are related to [https://github.com/unimelb/homepage/issues/1](url)

- changes the element to button, to make the component work in Firefox
- adds the link role to change the screen reader behavior to work like with default anchor tag
- changes the position of the button to be left aligned

Also I've tested this functionality in Safari and tab navigation works only with an option button pressed (it is a default behavior for safari). When using voiceover everything works as expected.

Could you please review?