### PR TITLE
fix(component): split section order bug

### DIFF
--- a/components/cards/_card-rounded-figure.css
+++ b/components/cards/_card-rounded-figure.css
@@ -46,7 +46,7 @@
   }
 
   .card__thumb {
-    height: 100%;
+    height: auto;
     width: auto;
     margin-bottom: 1.25rem;
     margin-right: .375rem;

--- a/components/section/_split-section.css
+++ b/components/section/_split-section.css
@@ -97,7 +97,7 @@
     &__inner {
       max-width: calc(var(--w-mid) / 2 + var(--vr)); /* account for either left or right padding */
       padding-top: calc(7 * var(--vr));
-      padding-bottom: calc(var(--vr));
+      padding-bottom: calc(2 * var(--vr));
     }
 
     &__side:first-child > .split-section__inner { margin-left: auto; }

--- a/components/section/_split-section.css
+++ b/components/section/_split-section.css
@@ -2,16 +2,21 @@
  * Split section
  */
 .split-section {
+  display: flex;
+  flex-direction: column;
+
   &--fullheight {
     min-height: 47.1rem;
   }
 
   /* left and right-hand sides are interchangeable */
   &__side {
+    order: 1;
     background-position: center;
     background-size: cover;
 
     &--with-image {
+      order: 0;
       padding-top: 56.25%;
     }
   }

--- a/components/section/_split-section.css
+++ b/components/section/_split-section.css
@@ -96,8 +96,8 @@
 
     &__inner {
       max-width: calc(var(--w-mid) / 2 + var(--vr)); /* account for either left or right padding */
-      padding-top: calc(4 * var(--vr));
-      padding-bottom: calc(4 * var(--vr));
+      padding-top: calc(7 * var(--vr));
+      padding-bottom: calc(var(--vr));
     }
 
     &__side:first-child > .split-section__inner { margin-left: auto; }

--- a/components/todo-list/TodoList.vue
+++ b/components/todo-list/TodoList.vue
@@ -26,7 +26,7 @@
         <div class="todo-list__fill" />
         <ButtonCard
           v-for="data in buttonCardData"
-          :key="data"
+          :key="data.id"
           :top-label="data.topLabel"
           :label="data.label"
           :link="data.link"


### PR DESCRIPTION
# Description

[Preview](https://deploy-preview-1476--pattern-lib-unimelb.netlify.app/?selectedKind=Section%2FSplit%20Section&selectedStory=Left&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Make sure to do not repeat yourself (DRY)
- [x] Snapshots tested
- [x] A11y tested
- [x] CSS utilises BEM naming convention and structure
- [x] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [x] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11