### PR TITLE
Reduce padding-top on split section text container

### DIFF
--- a/components/section/_split-section.css
+++ b/components/section/_split-section.css
@@ -96,7 +96,7 @@
 
     &__inner {
       max-width: calc(var(--w-mid) / 2 + var(--vr)); /* account for either left or right padding */
-      padding-top: calc(7 * var(--vr));
+      padding-top: calc(4 * var(--vr));
       padding-bottom: calc(2 * var(--vr));
     }
 


### PR DESCRIPTION
Reduces padding-top so text block still looks bottom-aligned but does not have excessive whitespace above it.
