### PR TITLE
chore(css): add focus wrapper deprecated classes back

### DIFF
--- a/components/_utils.css
+++ b/components/_utils.css
@@ -28,6 +28,12 @@
 .bg-inverted--o95 {
   background-color: rgba(var(--col-background-secondary-navy), .95);
   color: rgb(var(--col-background-primary-white));
+
+  .card--focus-box__cnr {
+    opacity: .85;
+
+    /* push up opacity for focus color on blue bg */
+  }
 }
 
 /* light-gray background */

--- a/components/cards/_card-focus-box.css
+++ b/components/cards/_card-focus-box.css
@@ -11,6 +11,85 @@
     text-align: center;
   }
 
+  &__cnr {
+    position: absolute;
+    width: 6rem;
+    height: 6rem;
+    opacity: .5;
+    color: rgb(var(--col-emerald-mid-2));
+
+    &--top-left {
+      top: 0;
+      left: 0;
+    }
+
+    &--btm-right {
+      right: 0;
+      bottom: 0;
+    }
+  }
+
+  /* Focus mark color modifiers */
+  &--brand {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-brand));
+    }
+  }
+
+  &--white {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-background-primary-white));
+    }
+  }
+
+  &--teal {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-teal-mid-2));
+    }
+  }
+
+  &--yellow {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-yellow-mid-2));
+    }
+  }
+
+  &--emerald {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-emerald-mid-2));
+    }
+  }
+
+  &--blue {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-blue-mid-2));
+    }
+  }
+
+  &--orange {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-orange-mid-2));
+    }
+  }
+
+  &--green {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-green-mid-2));
+    }
+  }
+
+  &--purple {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-purple-mid-2));
+    }
+  }
+
+  &--pink {
+    .card--focus-box__cnr {
+      color: rgb(var(--col-pink-mid-2));
+    }
+  }
+
   &__icon {
     width: 100%;
     max-width: 12.5rem;

--- a/components/print.css
+++ b/components/print.css
@@ -122,6 +122,10 @@
   .header-tools__menu,
   .card-focus__top-left,
   .card-focus__bottom-right,
+  .card--focus-box__cnr {
+    display: none !important;
+  }
+
   .page-footer__main__contacts {
     width: 100% !important;
   }
@@ -175,6 +179,7 @@
     background-color: transparent !important;
   }
 
+  .card--focus-box,
   .section__inner,
   .card--pathfinder,
   .notice {


### PR DESCRIPTION
Reverted focus wrapper classes, as the CMS is still dependent on them.

