### PR TITLE
fix accessibility role menuitem

### DIFF
--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -56,7 +56,7 @@
               @mouseout="dismissDesktopMenu"
               @keydown="handleKey">
               <a
-                :role="rootitem.items ? 'button' : 'menuitem'"
+                role="menuitem"
                 :href="rootitem.href"
                 class="menu__link"
                 @click="openInner">


### PR DESCRIPTION
# Description

## Type of change

Bug fix (accessibility issues - An element with role=menuitem must be contained in, or owned by, an element with role=menu or role=menubar)

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11