### PR TITLE
fix accessibility svg aria label

### DIFF
--- a/components/breadcrumbs/PageBreadcrumbs.vue
+++ b/components/breadcrumbs/PageBreadcrumbs.vue
@@ -22,7 +22,7 @@
           <SvgIcon
             v-if="index === 0"
             class="page-breadcrumbs__home"
-            name="home"
+            :name="'home'"
             width="18"
             height="18" />
           <span
@@ -31,8 +31,8 @@
           <SvgIcon
             v-if="index < items.length - 1"
             class="page-breadcrumbs__chevron"
-            name="chevron-right"
-            width="12"
+            :name="'chevron-right'"
+            width="22"
             height="12" />
         </a>
       </li>

--- a/components/breadcrumbs/PageBreadcrumbs.vue
+++ b/components/breadcrumbs/PageBreadcrumbs.vue
@@ -32,7 +32,7 @@
             v-if="index < items.length - 1"
             class="page-breadcrumbs__chevron"
             :name="'chevron-right'"
-            width="22"
+            width="12"
             height="12" />
         </a>
       </li>

--- a/components/cards/CardLink.vue
+++ b/components/cards/CardLink.vue
@@ -17,7 +17,7 @@
       <SvgIcon
         width="15px"
         height="15px"
-        name="chevron-right" />
+        :name="'chevron-right'" />
     </div>
   </a>
 </template>

--- a/components/cards/CardStaffList.vue
+++ b/components/cards/CardStaffList.vue
@@ -30,7 +30,7 @@
           title="profile phone number"
           aria-label="Phone Number">
           <SvgIcon
-            name="phone"
+            :name="'phone'"
             width="15px"
             height="15px" />
           {{ phone }}
@@ -42,7 +42,7 @@
           title="profile email"
           aria-label="Email">
           <SvgIcon
-            name="envelope"
+            :name="'envelope'"
             width="15px"
             height="15px" />
           {{ email }}

--- a/components/filter/accordion/AccordionFilter.vue
+++ b/components/filter/accordion/AccordionFilter.vue
@@ -53,7 +53,7 @@
           @click="filterDataButton">
           <SvgIcon
             class="filter__button--icon"
-            name="search" />
+            :name="'search'" />
           <span>Search</span>
         </button>
         <button

--- a/components/filter/cards-category/CardsFilterCategory.vue
+++ b/components/filter/cards-category/CardsFilterCategory.vue
@@ -76,7 +76,7 @@
                   class="filter-category__clear-btn-icon"
                   width="14px"
                   height="14px"
-                  name="close" />
+                  :name="'close'" />
                 Clear
               </button>
             </div>
@@ -137,7 +137,7 @@
                       <div
                         slot="sub-title-1"
                         class="sub-title">
-                        <SvgIcon name="clock" />
+                        <SvgIcon :name="'clock'" />
                         <span>{{ childItem.duration }} minutes</span>
                       </div>
                     </GenericCard>

--- a/components/filter/cards/CardsFilter.vue
+++ b/components/filter/cards/CardsFilter.vue
@@ -53,7 +53,7 @@
           @click="filterDataButton">
           <SvgIcon
             class="filter__button--icon"
-            name="search" />
+            :name="'search'" />
           <span>Search</span>
         </button>
         <button
@@ -94,7 +94,7 @@
                 View showcase
                 <SvgIcon
                   class="link-icon"
-                  name="chevron-right"
+                  :name="'chevron-right'"
                   width="10"
                   height="10" />
               </a>

--- a/components/filter/courses/CoursesFilter.vue
+++ b/components/filter/courses/CoursesFilter.vue
@@ -88,7 +88,7 @@
                 class="filter-courses__clear-btn-icon"
                 width="14px"
                 height="14px"
-                name="close" />
+                :name="'close'" />
               Clear
             </button>
           </div>

--- a/components/filters/components/filter-dropdown/FilterDropdown.vue
+++ b/components/filters/components/filter-dropdown/FilterDropdown.vue
@@ -24,7 +24,7 @@
 
       <div class="filter-dropdown__icon">
         <SvgIcon
-          name="chevron-down"
+          :name="'chevron-down'"
           class="push-icon__icon" />
       </div>
     </div>

--- a/components/focus-wrapper/FocusWrapper.vue
+++ b/components/focus-wrapper/FocusWrapper.vue
@@ -6,11 +6,11 @@
     <SvgIcon
       :class="['card-focus__top-left', color, { 'semi-opaque': semiOpaque }]"
       icon="focus-top-left"
-      name="focus-top-left" />
+      :name="'focus-top-left'" />
     <SvgIcon
       :class="['card-focus__bottom-right', color, { 'semi-opaque': semiOpaque }]"
       icon="focus-bottom-right"
-      name="focus-bottom-right" />
+      :name="'focus-bottom-right'" />
   </div>
 </template>
 

--- a/components/footer/PageFooterUpper.vue
+++ b/components/footer/PageFooterUpper.vue
@@ -29,7 +29,7 @@
                 href="#">
                 <SvgIcon
                   class="page-footer-search__icon"
-                  name="search" />
+                  :name="'search'" />
               </button>
             </div>
           </form>
@@ -57,7 +57,7 @@
                 href="https://about.unimelb.edu.au/strategy/our-structure/faculties-and-graduate-schools">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="faculty" />
+                  :name="'faculty'" />
                 <span class="link-icon__text">Faculties &amp; graduate schools</span>
               </a>
             </li>
@@ -67,7 +67,7 @@
                 href="https://maps.unimelb.edu.au">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="location" />
+                  :name="'location'" />
                 <span class="link-icon__text">Maps</span>
               </a>
             </li>
@@ -77,7 +77,7 @@
                 href="https://library.unimelb.edu.au">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="library" />
+                  :name="'library'" />
                 <span class="link-icon__text">Library</span>
               </a>
             </li>
@@ -87,7 +87,7 @@
                 href="https://www.alumni.unimelb.edu.au/give">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="campaign" />
+                  :name="'campaign'" />
                 <span class="link-icon__text">Support the campaign</span>
               </a>
             </li>
@@ -97,7 +97,7 @@
                 href="https://www.unimelb.edu.au/contact">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="phone" />
+                  :name="'phone'" />
                 <span class="link-icon__text">Contact us</span>
               </a>
             </li>
@@ -107,7 +107,7 @@
                 href="https://about.unimelb.edu.au/careers">
                 <SvgIcon
                   class="link-icon__icon svg"
-                  name="jobs" />
+                  :name="'jobs'" />
                 <span class="link-icon__text">Jobs</span>
               </a>
             </li>

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -63,11 +63,11 @@
                 {{ rootitem.title }}
                 <SvgIcon
                   v-if="!isMobileOpen && rootitem.items"
-                  name="chevron-down"
+                  :name="'chevron-down'"
                   class="icon" />
                 <SvgIcon
                   v-if="isMobileOpen"
-                  name="chevron-right"
+                  :name="'chevron-right'"
                   class="icon" />
               </a>
               <div
@@ -100,7 +100,7 @@
                         {{ menuitem.title }}
                         <SvgIcon
                           v-if="!isMobileOpen"
-                          name="chevron-right"
+                          :name="'chevron-right'"
                           class="icon" />
                       </a>
                     </li>
@@ -134,7 +134,7 @@
                         class="link">
                         View more details
                         <SvgIcon
-                          name="chevron-right"
+                          :name="'chevron-right'"
                           class="icon" />
                       </a>
                     </div>

--- a/components/navigation/InPageNavigation.vue
+++ b/components/navigation/InPageNavigation.vue
@@ -20,7 +20,7 @@
             @click="scrollOnClick">
             {{ data.label }}
             <SvgIcon
-              name="chevron-right"
+              :name="'chevron-right'"
               class="in-page-navigation__icon" />
           </a>
         </li>

--- a/components/profiles/accordion-profile/AccordionProfile.vue
+++ b/components/profiles/accordion-profile/AccordionProfile.vue
@@ -28,7 +28,7 @@
             v-if="bio"
             :class="iconClassName"
             class="accordion-profile__icon"
-            name="chevron-up"
+            :name="'chevron-up'"
             aria-label="chevron"
             width="14px"
             height="14px" />

--- a/components/quick-links-menu/QuickLinksMenuItem.vue
+++ b/components/quick-links-menu/QuickLinksMenuItem.vue
@@ -6,7 +6,7 @@
       <span :class="{ 'push-icon__text': truncate }">{{ title }}</span>
       <SvgIcon
         class="push-icon__icon"
-        name="chevron-right"
+        :name="'chevron-right'"
         height="16"
         width="16" />
     </span>

--- a/components/search/PageSearch.vue
+++ b/components/search/PageSearch.vue
@@ -6,7 +6,7 @@
       @keypress.enter="open">
       <SvgIcon
         class="link-icon__icon svg"
-        name="search" />
+        :name="'search'" />
       <span class="link-icon__text">Search</span>
     </button>
     <div
@@ -21,7 +21,7 @@
           @click.prevent="close">
           <SvgIcon
             class="page-header-search__icon--close"
-            name="close" />
+            :name="'close'" />
           Close
         </a>
       </PageSearchForm>

--- a/components/search/PageSearchForm.vue
+++ b/components/search/PageSearchForm.vue
@@ -14,7 +14,7 @@
         type="submit">
         <SvgIcon
           class="page-header-search__icon"
-          name="search" />
+          :name="'search'" />
         <span class="screenreaders-only">Go</span>
       </button>
     <slot />

--- a/components/side-panel/SidePanel.vue
+++ b/components/side-panel/SidePanel.vue
@@ -10,7 +10,7 @@
           <SvgIcon
             width="10"
             height="10"
-            name="close" />
+            :name="'close'" />
         </button>
       </h5>
       <ul

--- a/components/side-panel/SidePanelNavItem.vue
+++ b/components/side-panel/SidePanelNavItem.vue
@@ -12,7 +12,7 @@
         <slot />
         <SvgIcon
           class="push-icon__icon"
-          name="chevron-right"
+          :name="'chevron-right'"
           width="10"
           height="10" />
       </span>

--- a/components/social-media-bar/SocialMediaBar.vue
+++ b/components/social-media-bar/SocialMediaBar.vue
@@ -23,7 +23,7 @@
             :href="blogLink"
             class="social-media-bar__link social-media-bar__link--content">
             <SvgIcon
-              name="newspaper"
+              :name="'newspaper'"
               width="25"
               height="25"
               class="social-media-bar__icon" />Read our blog

--- a/components/sublink-menu/SublinkMenuItem.vue
+++ b/components/sublink-menu/SublinkMenuItem.vue
@@ -6,7 +6,7 @@
       <slot name="link" />
       <SvgIcon
         class="push-icon__icon"
-        name="chevron-right"
+        :name="'chevron-right'"
         height="12"
         width="12" />
     </a>


### PR DESCRIPTION
# Description

I was investigating accessibility issues:
“SVG elements with graphic role attributes must have an accessible name.
SVG elements with role=img, role=graphics-document or role=graphics-symbol need an accessible name provided by the SVG title element or an ARIA label.”
Component SvgIcon takes props “name”  which we are forming “aria-label”.
I think In many components props “name” are not transferred for component SvgIcon.
Thank you

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11