### PR TITLE
fix accessibility tablist-must contain tab

### DIFF
--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -37,11 +37,10 @@
           aria-hidden="true" />
       </div>
       <div
-        v-if="!useSelect && panels.length"
+        v-if="!useSelect"
         ref="tabsList"
         class="tabs__tablist"
         :class="tabsListClasses"
-        role="tablist"
         @keyup="handleKey">
         <a
           v-for="(tab, index) in panels"
@@ -186,6 +185,7 @@ export default {
       setTimeout(() => {
         this.tabsWidth = this.calculateTabsWidth();
         this.showControls = this.hasControls();
+        this.$refs.tabsList.setAttribute('role', 'tablist');
       }, TIMER_2000);
     },
   },

--- a/components/tabs/Tabs.vue
+++ b/components/tabs/Tabs.vue
@@ -37,7 +37,7 @@
           aria-hidden="true" />
       </div>
       <div
-        v-if="!useSelect"
+        v-if="!useSelect && panels.length"
         ref="tabsList"
         class="tabs__tablist"
         :class="tabsListClasses"

--- a/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
+++ b/components/tabs/__tests__/__snapshots__/Tabs.test.js.snap
@@ -13,7 +13,6 @@ exports[`Tabs should be alternate tab with yellow border 1`] = `
      
     <div
       class="tabs__tablist tabs__tablist--alt tabs__tablist--yellow"
-      role="tablist"
     />
      
     <!---->
@@ -38,7 +37,6 @@ exports[`Tabs should match snapshot 1`] = `
      
     <div
       class="tabs__tablist"
-      role="tablist"
     />
      
     <!---->


### PR DESCRIPTION
# Description

I suggest that the problem is caused by the fact, that during the testing on accessibility the array panels isn't ready due to the fix: https://github.com/unimelb/pattern-lib/blob/dev/components/tabs/Tabs.vue#L185
I am adding “role: tablist” when array is ready to be rendered. This could solve the problem.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11