### PR TITLE
fix accessibility element with role menuitem

### DIFF
--- a/components/carousel/Carousel.vue
+++ b/components/carousel/Carousel.vue
@@ -39,12 +39,12 @@
               v-for="(story, index) in storiesData"
               :key="index"
               class="carousel__navigation-item list-reset"
-              role="menuitem">
+              role="none">
               <a
                 :class="{ 'carousel__navigation-link--active': story.isActive }"
                 class="carousel__navigation-link"
                 href="javascript: void(0);"
-
+                role="menuitem"
                 @click="moveToStory(index)"
                 @focusin="stopSliding"
                 @keydown.enter="moveToStory(index)"

--- a/components/carousel/__tests__/__snapshots__/Carousel.test.js.snap
+++ b/components/carousel/__tests__/__snapshots__/Carousel.test.js.snap
@@ -41,11 +41,12 @@ exports[`Carousel should match snapshot 1`] = `
         >
           <li
             class="carousel__navigation-item list-reset"
-            role="menuitem"
+            role="none"
           >
             <a
               class="carousel__navigation-link carousel__navigation-link--active"
               href="javascript: void(0);"
+              role="menuitem"
             >
               
               Story 1
@@ -54,11 +55,12 @@ exports[`Carousel should match snapshot 1`] = `
           </li>
           <li
             class="carousel__navigation-item list-reset"
-            role="menuitem"
+            role="none"
           >
             <a
               class="carousel__navigation-link"
               href="javascript: void(0);"
+              role="menuitem"
             >
               
               Story 2

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -50,6 +50,7 @@
               v-for="(rootitem, rootindex) in items"
               ref="rootitems"
               :key="`rootitem-${rootindex}`"
+              role="none"
               tabindex="0"
               class="menu__item"
               @mouseover="activateDesktopMenu(rootindex)"
@@ -92,6 +93,7 @@
                     <li
                       v-for="(menuitem, menuindex) in rootitem.items"
                       :key="`menuitem-${menuindex}`"
+                      role="none"
                       class="menu__item">
                       <a
                         :href="menuitem.href"


### PR DESCRIPTION
# Description

fix: An element with role=menuitem must be contained in, or owned by, an element with role=menu or role=menubar
https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11