### PR TITLE
Add bordered section to the docs, update mobile spacing

### DIFF
--- a/components/_shims.css
+++ b/components/_shims.css
@@ -25,13 +25,45 @@
 .shim-pt067 { padding-top: calc(var(--vr) / 3 * 2) !important; }
 .shim-pb067 { padding-bottom: calc(var(--vr) / 3 * 2) !important; }
 
-.shim-mt1 { margin-top: var(--vr) !important; }
-.shim-mb1 { margin-bottom: var(--vr) !important; }
+.shim-mt1 {
+  margin-top: var(--vr) !important;
+
+  &--desk {
+    @media (--bp-desktop) {
+      margin-top: var(--vr) !important;
+    }
+  }
+}
+.shim-mb1 {
+  margin-bottom: var(--vr) !important;
+
+  &--desk {
+    @media (--bp-desktop) {
+      margin-bottom: var(--vr) !important;
+    }
+  }
+}
 .shim-pt1 { padding-top: var(--vr) !important; }
 .shim-pb1 { padding-bottom: var(--vr) !important; }
 
-.shim-mt2 { margin-top: calc(2 * var(--vr)) !important; }
-.shim-mb2 { margin-bottom: calc(2 * var(--vr)) !important; }
+.shim-mt2 {
+  margin-top: calc(2 * var(--vr)) !important;
+
+  &--desk {
+    @media (--bp-desktop) {
+      margin-top: calc(2 * var(--vr)) !important;
+    }
+  }
+}
+.shim-mb2 {
+  margin-bottom: calc(2 * var(--vr)) !important;
+
+  &--desk {
+    @media (--bp-desktop) {
+      margin-bottom: calc(2 * var(--vr)) !important;
+    }
+  }
+}
 .shim-pt2 { padding-top: calc(2 * var(--vr)) !important; }
 .shim-pb2 { padding-bottom: calc(2 * var(--vr)) !important; }
 

--- a/components/helpers/stories/ShimMb.vue
+++ b/components/helpers/stories/ShimMb.vue
@@ -67,6 +67,9 @@
     <p class="shim-mb1">
       shim-mb1
     </p>
+    <p class="shim-mb1--desk">
+      shim-mb1--desk
+    </p>
     <p class="shim-pt1">
       shim-pt1
     </p>
@@ -76,8 +79,14 @@
     <p class="shim-mt2">
       shim-mt2
     </p>
+    <p class="shim-mt2--desk">
+      shim-mt2--desk
+    </p>
     <p class="shim-mb2">
       shim-mb2
+    </p>
+    <p class="shim-mb2--desk">
+      shim-mb2--desk
     </p>
     <p class="shim-pt2">
       shim-pt2

--- a/components/section/_section-alt.css
+++ b/components/section/_section-alt.css
@@ -82,7 +82,7 @@
   &__left {
     position: relative;
     max-width: 28rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
 
     @media (--bp-desktop) {
       width: calc(4 / 12 * 100%);

--- a/components/today/stories/Section/Bordered.vue
+++ b/components/today/stories/Section/Bordered.vue
@@ -1,0 +1,38 @@
+<template>
+  <SectionAlt
+    bordered>
+    <h2 class="heading-md">
+      Section heading
+    </h2>
+    <div class="grid grid--lg">
+      <div class="cell cell--lg cell--tab-1of3 shim-mt0 shim-mb0 content-max-width">
+        <h3 class="heading-sm border-top">
+          Column 1
+        </h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean molestie mattis nisl eu tincidunt. Vivamus nulla erat, hendrerit non lectus eget, accumsan sagittis leo.</p>
+      </div>
+      <div class="cell cell--lg cell--tab-1of3 shim-mt0 shim-mb0 content-max-width">
+        <h3 class="heading-sm border-top">
+          Column 2
+        </h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean molestie mattis nisl eu tincidunt. Vivamus nulla erat, hendrerit non lectus eget, accumsan sagittis leo.</p>
+      </div>
+      <div class="cell cell--lg cell--tab-1of3 shim-mt0 shim-mb0 content-max-width">
+        <h3 class="heading-sm border-top">
+          Column 3
+        </h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean molestie mattis nisl eu tincidunt. Vivamus nulla erat, hendrerit non lectus eget, accumsan sagittis leo.</p>
+      </div>
+    </div>
+  </SectionAlt>
+</template>
+
+<script>
+import SectionAlt from 'components/section/SectionAlt.vue';
+import SectionAltMd from './SectionAlt.md';
+
+export default {
+  components: { SectionAlt },
+  readme: { custom: SectionAltMd, html: true, source: true },
+};
+</script>

--- a/components/today/stories/Section/Columns.vue
+++ b/components/today/stories/Section/Columns.vue
@@ -5,26 +5,26 @@
         Why study at Melbourne
       </h2>
     </div>
-    <div class="grid">
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+    <div class="grid grid--lg">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <h3 class="heading-sm shim-mb033">
           #1 in Australia
         </h3>
         <p>We’re ranked #1 in Australia for teaching quality. You’ll be studying alongside exceptional teachers and students.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <h3 class="heading-sm shim-mb033">
           Globally recognised
         </h3>
         <p>We are a world-leading and globally-connected Australian university, with partnerships all around the world.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <h3 class="heading-sm shim-mb033">
           Learn from the best
         </h3>
         <p>Our academics include community, government and business experts, as well as Nobel Laureates and Rhodes Scholars.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <h3 class="heading-sm shim-mb033">
           Pursue your passions
         </h3>

--- a/components/today/stories/Section/StandardWithColumns.vue
+++ b/components/today/stories/Section/StandardWithColumns.vue
@@ -16,8 +16,8 @@
       <p>Committed to life-long learning, we offer a range of short courses allowing you to rapidly advance your skills and pursue your passions.</p>
       <p>Our range of short courses include seminars, masterclasses, short-term intensives, CPD programs, professional development sessions and classes.</p>
     </div>
-    <div class="grid grid--lg shim-mt2">
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+    <div class="grid grid--lg shim-mt2--desk">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -29,7 +29,7 @@
         </h4>
         <p>Develop highly relevant skills and knowledge to apply in your industry immediately.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -41,7 +41,7 @@
         </h4>
         <p>High quality learning underpinned by cutting-edge research for solving real-world challenges.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -53,7 +53,7 @@
         </h4>
         <p>Gain skills and capabilities to succeed in a changing world.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -65,7 +65,7 @@
         </h4>
         <p>Quick, accessible upskilling enabling you to curate your own professional development pathway.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -77,7 +77,7 @@
         </h4>
         <p>Stack toward a degree with <strong>Melbourne MicroCerts</strong>. Opportunity to deepen your knowledge or build up to a University of Melbourne degree over time.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb1">
+      <div class="cell cell--lg cell--tab-1of2 content-max-width shim-mt0 shim-mb0 shim-mb1--desk">
         <SvgIcon
           name="briefcase"
           width="40"

--- a/components/today/stories/Section/ThreeUp.vue
+++ b/components/today/stories/Section/ThreeUp.vue
@@ -1,10 +1,10 @@
 <template>
   <SectionAlt>
-    <h2 class="heading-md shim-mb2">
+    <h2 class="heading-md shim-mb2--desk">
       Level up with Melbourne MicroCerts
     </h2>
     <div class="grid grid--lg">
-      <div class="cell cell--lg cell--tab-1of3 shim-mb1 shim-mt0 content-max-width">
+      <div class="cell cell--lg cell--tab-1of3 shim-mb0 shim-mt0 content-max-width">
         <SvgIcon
           name="briefcase"
           width="40"
@@ -15,7 +15,7 @@
         </h3>
         <p>Develop your leadership communication skills aligned with current industry best practice. <a href="#">Learn more about MicroCerts</a>.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of3 shim-mb1 shim-mt0 content-max-width">
+      <div class="cell cell--lg cell--tab-1of3 shim-mb0 shim-mt0 content-max-width">
         <SvgIcon
           name="handshake"
           width="40"
@@ -26,7 +26,7 @@
         </h3>
         <p>Your teachers are internationally recognised professionals with years of on the ground experience within top organisations.</p>
       </div>
-      <div class="cell cell--lg cell--tab-1of3 shim-mb1 shim-mt0 content-max-width">
+      <div class="cell cell--lg cell--tab-1of3 shim-mb0 shim-mt0 content-max-width">
         <SvgIcon
           name="check"
           width="40"

--- a/components/today/stories/Section/index.js
+++ b/components/today/stories/Section/index.js
@@ -5,9 +5,11 @@ import StandardWithColumns from './StandardWithColumns.vue';
 import StandardWithImage from './StandardWithImage.vue';
 import ThreeUp from './ThreeUp.vue';
 import Columns from './Columns.vue';
+import Bordered from './Bordered.vue';
 
 storiesOf('Today/Section', module)
   .add('Standard (with columns)', createStory(StandardWithColumns))
   .add('Standard (with image)', createStory(StandardWithImage))
   .add('3 Up', createStory(ThreeUp))
-  .add('Columns', createStory(Columns));
+  .add('Columns', createStory(Columns))
+  .add('Bordered', createStory(Bordered));


### PR DESCRIPTION
# Description

After eyeballing the sections on mobile, I think we could tighten up the spacing a bit - trying to catch this now before it's in the CMS and more difficult to update markup.

I've added some responsive helpers for the shim margin helpers.

I've also added a `Bordered` example to the docs - this is not required for the CMS, but thought it would be good to document that variation too (used on the Microcert page in FAC).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11