### PR TITLE
(fix) Page footer alt links

### DIFF
--- a/components/footer/PageFooterAlt.vue
+++ b/components/footer/PageFooterAlt.vue
@@ -145,7 +145,7 @@ export default {
       defaultPrimaryLinks: [
         { text: 'About us', href: 'https://about.unimelb.edu.au/' },
         { text: 'Careers at Melbourne', href: 'https://about.unimelb.edu.au/careers' },
-        { text: 'Alumni', href: 'https://www.unimelb.edu.au/alumni' },
+        { text: 'Safety and respect', href: 'https://students.unimelb.edu.au/campus-life/policy-and-conduct/respect-at-the-university' },
         { text: 'Newsroom', href: 'https://about.unimelb.edu.au/newsroom' },
         { text: 'Contact', href: 'https://www.unimelb.edu.au/contact' },
       ],

--- a/components/megamenu/MegaMenuAlt.vue
+++ b/components/megamenu/MegaMenuAlt.vue
@@ -1,0 +1,169 @@
+<template>
+  <header class="mega-menu-alt">
+    <a
+      href="#main"
+      class="mega-menu-alt__skip-link screen-reader-jump-to__skippy screenreaders-only screenreaders-only-focusable btn--inverted btn btn--xsml">
+      Skip to content
+    </a>
+    <div class="mega-menu-alt__inner bg-inverted">
+      <Logo size="md" />
+      <div class="mega-menu-alt__menu">
+        <div class="mega-menu-alt__menu-top">
+          <nav aria-label="Quick links">
+            <ul class="mega-menu-alt__secondary-links list-reset">
+              <li
+                v-for="(link, index) in secondaryLinks"
+                :key="index">
+                <a
+                  :href="link.href"
+                  class="link-reset">
+                  {{ link.text }}
+                </a>
+              </li>
+            </ul>
+          </nav>
+          <ul class="mega-menu-alt__actions list-reset">
+            <li class="mega-menu-alt__contact">
+              <a
+                href="https://www.unimelb.edu.au/contact"
+                class="link-reset">
+                Contact
+              </a>
+            </li>
+            <li class="mega-menu-alt__search">
+              <button
+                ref="searchBtn"
+                :aria-expanded="String(isSearchOpen)"
+                class="link-reset"
+                @click="openSearch">
+                Search
+                <svg
+                  focusable="false"
+                  role="presentation">
+                  <use xlink:href="#icon-search" />
+                </svg>
+              </button>
+            </li>
+            <li class="mega-menu-alt__mobile-menu">
+              <button
+                ref="menuBtn"
+                :aria-expanded="String(isMobileOpen)"
+                class="link-reset"
+                @click="openMobileMenu">
+                Menu
+                <svg
+                  focusable="false"
+                  aria-label="icon menu"
+                  viewBox="10 10 26 28">
+                  <path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z" />
+                </svg>
+              </button>
+            </li>
+          </ul>
+        </div>
+        <nav aria-label="Site">
+          <ul class="mega-menu-alt__primary-links list-reset">
+            <li
+              v-for="(link, index) in primaryLinks"
+              :key="index">
+              <a
+                :href="link.href"
+                class="link-reset">
+                {{ link.text }}
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <MegaMenuAltMobile
+          v-model="isMobileOpen"
+          :primary-links="primaryLinks"
+          :secondary-links="secondaryLinks"
+          @close="closeMobileMenu" />
+        <div
+          class="page-header-search"
+          :class="{ active: isSearchOpen }"
+          @keydown.esc="closeSearch">
+          <Trap :disabled="!isSearchOpen">
+            <PageSearchForm>
+              <a
+                href="#"
+                aria-haspopup="true"
+                class="page-header-search__close link-reset"
+                @click.prevent="closeSearch">
+                <svg
+                  focusable="false"
+                  role="presentation">
+                  <use xlink:href="#icon-close" />
+                </svg>
+                Close
+              </a>
+            </PageSearchForm>
+          </Trap>
+        </div>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script>
+import Trap from 'vue-focus-lock';
+import PageSearchForm from 'components/search/PageSearchForm.vue';
+import Logo from 'components/logo/Logo.vue';
+import MegaMenuAltMobile from './MegaMenuAltMobile.vue';
+
+export default {
+  components: {
+    Logo,
+    MegaMenuAltMobile,
+    PageSearchForm,
+    Trap,
+  },
+  data() {
+    return {
+      isMobileOpen: false,
+      isSearchOpen: false,
+      primaryLinks: [
+        { text: 'Home', href: '/home-page' },
+        { text: 'Study at Melbourne', href: 'https://study.unimelb.edu.au/' },
+        { text: 'Research and innovation', href: 'https://research.unimelb.edu.au/' },
+        { text: 'About us', href: 'https://about.unimelb.edu.au/' },
+        { text: 'Virtual Campus', href: 'https://study.unimelb.edu.au/discover/virtual-tour' },
+      ],
+      secondaryLinks: [
+        { text: 'Current students', href: 'https://students.unimelb.edu.au/' },
+        { text: 'Staff', href: 'https://staff.unimelb.edu.au/' },
+        { text: 'Library', href: 'https://library.unimelb.edu.au/' },
+      ],
+    };
+  },
+  computed: {
+    mobileMenuLinks() {
+      return [
+        ...this.primaryLinks,
+        ...this.secondaryLinks,
+        { text: 'Contact', href: 'https://www.unimelb.edu.au/contact' },
+      ];
+    },
+  },
+  methods: {
+    openMobileMenu() {
+      this.isMobileOpen = true;
+    },
+    openSearch() {
+      this.isSearchOpen = true;
+    },
+    closeMobileMenu() {
+      this.isMobileOpen = false;
+      this.$nextTick(() => {
+        this.$refs.menuBtn.focus();
+      });
+    },
+    closeSearch() {
+      this.isSearchOpen = false;
+      this.$nextTick(() => {
+        this.$refs.searchBtn.focus();
+      });
+    },
+  },
+};
+</script>

--- a/components/megamenu/MegaMenuAlt.vue
+++ b/components/megamenu/MegaMenuAlt.vue
@@ -126,13 +126,14 @@ export default {
         { text: 'Home', href: '/home-page' },
         { text: 'Study at Melbourne', href: 'https://study.unimelb.edu.au/' },
         { text: 'Research and innovation', href: 'https://research.unimelb.edu.au/' },
-        { text: 'About us', href: 'https://about.unimelb.edu.au/' },
+        { text: 'Safety and respect', href: 'https://students.unimelb.edu.au/campus-life/policy-and-conduct/respect-at-the-university' },
         { text: 'Virtual Campus', href: 'https://study.unimelb.edu.au/discover/virtual-tour' },
       ],
       secondaryLinks: [
         { text: 'Current students', href: 'https://students.unimelb.edu.au/' },
         { text: 'Staff', href: 'https://staff.unimelb.edu.au/' },
         { text: 'Library', href: 'https://library.unimelb.edu.au/' },
+        { text: 'Alumni', href: 'https://www.unimelb.edu.au/alumni' },
       ],
     };
   },

--- a/components/megamenu/MegaMenuAltMobile.vue
+++ b/components/megamenu/MegaMenuAltMobile.vue
@@ -1,0 +1,117 @@
+<template>
+  <div
+    class="mega-menu-alt-mobile"
+    @click="handleClick"
+    @keydown.esc="closeMenu">
+    <div
+      ref="inner"
+      v-scroll-lock="value"
+      class="mega-menu-alt-mobile__inner">
+      <Trap :disabled="!value">
+        <button
+          class="mega-menu-alt-mobile__close"
+          @click="$emit('close')">
+          <svg
+            focusable="false"
+            role="presentation">
+            <use xlink:href="#icon-close" />
+          </svg>
+          Close
+        </button>
+        <nav
+          v-if="primaryLinks.length"
+          aria-label="Site">
+          <ul class="mega-menu-alt-mobile__links list-reset">
+            <li
+              v-for="(link, index) in primaryLinks"
+              :key="index">
+              <a
+                :href="link.href"
+                class="link-reset">
+                {{ link.text }}
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <nav
+          v-if="secondaryLinks.length"
+          aria-label="Quick links">
+          <ul class="mega-menu-alt-mobile__links mega-menu-alt-mobile__links--secondary list-reset">
+            <li
+              v-for="(link, index) in secondaryLinks"
+              :key="index">
+              <a
+                :href="link.href"
+                class="link-reset">
+                {{ link.text }}
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </Trap>
+    </div>
+  </div>
+</template>
+
+<script>
+import Trap from 'vue-focus-lock';
+
+export default {
+  components: {
+    Trap,
+  },
+  props: {
+    value: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    primaryLinks: {
+      type: Array,
+      required: false,
+      default() {
+        return [];
+      },
+    },
+    secondaryLinks: {
+      type: Array,
+      required: false,
+      default() {
+        return [];
+      },
+    },
+  },
+  watch: {
+    value(val) {
+      if (val) {
+        this.$el.setAttribute('style', 'display: block;');
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            this.$el.classList.add('is-open');
+            document.body.classList.add('mobile-menu-is-open');
+          });
+        });
+      } else {
+        this.$el.classList.remove('is-open');
+        document.body.classList.remove('mobile-menu-is-open');
+        this.$refs.inner.addEventListener('transitionend', () => {
+          if (this.value) {
+            return;
+          }
+          this.$el.setAttribute('style', 'display: none;');
+        }, { once: true });
+      }
+    },
+  },
+  methods: {
+    handleClick(evt) {
+      if (!this.$refs.inner.contains(evt.target)) {
+        this.closeMenu();
+      }
+    },
+    closeMenu() {
+      this.$emit('input', false);
+    },
+  },
+};
+</script>

--- a/components/megamenu/__tests__/MegaMenuAlt.test.js
+++ b/components/megamenu/__tests__/MegaMenuAlt.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'vue-test-utils';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import MegaMenuAlt from '../MegaMenuAlt.vue';
+
+expect.extend(toHaveNoViolations);
+
+describe('MegaMenuAlt', () => {
+  it('should match snapshot', () => {
+    const result = shallow(MegaMenuAlt).element;
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Component throws no accessibility violations', (done) => {
+    // Set up our document body
+    document.body.innerHTML = '<main id="main">'
+        + '</main>';
+    const html = shallow(MegaMenuAlt).html();
+    // pass anything that outputs html to axe
+    return axe(html).then((response) => {
+      expect(response).toHaveNoViolations();
+      done();
+    });
+  });
+});

--- a/components/megamenu/__tests__/MegaMenuAltMobile.test.js
+++ b/components/megamenu/__tests__/MegaMenuAltMobile.test.js
@@ -1,0 +1,22 @@
+import { shallow } from 'vue-test-utils';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import MegaMenuAltMobile from '../MegaMenuAltMobile.vue';
+
+expect.extend(toHaveNoViolations);
+
+describe('MegaMenuAltMobile', () => {
+  it('should match snapshot', () => {
+    const result = shallow(MegaMenuAltMobile).element;
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Component throws no accessibility violations', (done) => {
+    const html = shallow(MegaMenuAltMobile).html();
+    // pass anything that outputs html to axe
+    return axe(html).then((response) => {
+      expect(response).toHaveNoViolations();
+      done();
+    });
+  });
+});

--- a/components/megamenu/__tests__/__snapshots__/MegaMenuAlt.test.js.snap
+++ b/components/megamenu/__tests__/__snapshots__/MegaMenuAlt.test.js.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MegaMenuAlt should match snapshot 1`] = `
+<header
+  class="mega-menu-alt"
+>
+  <a
+    class="mega-menu-alt__skip-link screen-reader-jump-to__skippy screenreaders-only screenreaders-only-focusable btn--inverted btn btn--xsml"
+    href="#main"
+  >
+    
+    Skip to content
+  
+  </a>
+   
+  <div
+    class="mega-menu-alt__inner bg-inverted"
+  >
+    <!---->
+     
+    <div
+      class="mega-menu-alt__menu"
+    >
+      <div
+        class="mega-menu-alt__menu-top"
+      >
+        <nav
+          aria-label="Quick links"
+        >
+          <ul
+            class="mega-menu-alt__secondary-links list-reset"
+          >
+            <li>
+              <a
+                class="link-reset"
+                href="https://students.unimelb.edu.au/"
+              >
+                
+                Current students
+              
+              </a>
+            </li>
+            <li>
+              <a
+                class="link-reset"
+                href="https://staff.unimelb.edu.au/"
+              >
+                
+                Staff
+              
+              </a>
+            </li>
+            <li>
+              <a
+                class="link-reset"
+                href="https://library.unimelb.edu.au/"
+              >
+                
+                Library
+              
+              </a>
+            </li>
+          </ul>
+        </nav>
+         
+        <ul
+          class="mega-menu-alt__actions list-reset"
+        >
+          <li
+            class="mega-menu-alt__contact"
+          >
+            <a
+              class="link-reset"
+              href="https://www.unimelb.edu.au/contact"
+            >
+              
+              Contact
+            
+            </a>
+          </li>
+           
+          <li
+            class="mega-menu-alt__search"
+          >
+            <button
+              aria-expanded="false"
+              class="link-reset"
+            >
+              
+              Search
+              
+              <svg
+                focusable="false"
+                role="presentation"
+              >
+                <use
+                  xlink:href="#icon-search"
+                />
+              </svg>
+            </button>
+          </li>
+           
+          <li
+            class="mega-menu-alt__mobile-menu"
+          >
+            <button
+              aria-expanded="false"
+              class="link-reset"
+            >
+              
+              Menu
+              
+              <svg
+                aria-label="icon menu"
+                focusable="false"
+                viewBox="10 10 26 28"
+              >
+                <path
+                  d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </div>
+       
+      <nav
+        aria-label="Site"
+      >
+        <ul
+          class="mega-menu-alt__primary-links list-reset"
+        >
+          <li>
+            <a
+              class="link-reset"
+              href="/home-page"
+            >
+              
+              Home
+            
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-reset"
+              href="https://study.unimelb.edu.au/"
+            >
+              
+              Study at Melbourne
+            
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-reset"
+              href="https://research.unimelb.edu.au/"
+            >
+              
+              Research and innovation
+            
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-reset"
+              href="https://about.unimelb.edu.au/"
+            >
+              
+              About us
+            
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-reset"
+              href="https://study.unimelb.edu.au/discover/virtual-tour"
+            >
+              
+              Virtual Campus
+            
+            </a>
+          </li>
+        </ul>
+      </nav>
+       
+      <!---->
+       
+      <div
+        class="page-header-search"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</header>
+`;

--- a/components/megamenu/__tests__/__snapshots__/MegaMenuAltMobile.test.js.snap
+++ b/components/megamenu/__tests__/__snapshots__/MegaMenuAltMobile.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MegaMenuAltMobile should match snapshot 1`] = `
+<div
+  class="mega-menu-alt-mobile"
+>
+  <div
+    class="mega-menu-alt-mobile__inner"
+  >
+    <!---->
+  </div>
+</div>
+`;

--- a/components/megamenu/_mega-menu-alt-mobile.css
+++ b/components/megamenu/_mega-menu-alt-mobile.css
@@ -1,0 +1,76 @@
+.mega-menu-alt-mobile {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(var(--col-black-dark), 0);
+  z-index: 10;
+  transition: background .3s ease;
+  display: none;
+
+  @media (--bp-desktop) {
+    display: none;
+  }
+
+  &.is-open {
+    background: rgba(var(--col-black-dark), .5);
+  }
+
+  &__inner {
+    background-color: rgb(var(--col-brand));
+    width: 100%;
+    height: 100%;
+    margin-left: auto;
+    opacity: 0;
+    transform: translateX(100%);
+    transition: transform .3s ease;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 18.75rem;
+
+    .mega-menu-alt-mobile.is-open & {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    padding: 1.25rem;
+    background-color: rgb(var(--col-background-tertiary-navy));
+    width: 100%;
+    margin-bottom: 1rem;
+
+    svg {
+      width: .75rem;
+      height: .75rem;
+      margin-right: .5rem;
+    }
+  }
+
+  &__links {
+    margin-bottom: 1.5rem;
+
+    a {
+      display: block;
+      padding: .5rem 1.25rem;
+      font-size: 1.125rem;
+    }
+
+    &--secondary a {
+      font-size: 1rem;
+      color: rgba(var(--col-white), .8) !important;
+      padding: .25rem 1.25rem;
+    }
+  }
+
+  &__search {
+    padding: .5rem 1.25rem;
+  }
+}
+
+.mega-menu-alt-mobile-is-open {
+  overflow: hidden;
+}

--- a/components/megamenu/_mega-menu-alt.css
+++ b/components/megamenu/_mega-menu-alt.css
@@ -1,0 +1,139 @@
+.mega-menu-alt {
+  &__inner {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    height: 6rem;
+    display: flex;
+    align-items: center;
+  }
+
+  &__menu {
+    padding-left: 1.5rem;
+    flex: 1;
+
+    &-top {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+
+  &__primary-links,
+  &__secondary-links {
+    display: none;
+
+    @media (--bp-desktop) {
+      display: flex;
+      flex-wrap: wrap;
+      margin: .25rem -.5rem;
+
+      li {
+        margin: .25rem .5rem;
+      }
+    }
+  }
+
+  &__secondary-links {
+    color: rgba(var(--col-white), .8);
+    font-size: .875rem;
+    margin-bottom: .5rem;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex: 1;
+    font-size: .875rem;
+    margin: .25rem 0;
+
+    li {
+      margin: .25rem .75rem 0;
+
+      @media (--bp-desktop) {
+        margin: .25rem .5rem;
+      }
+    }
+
+    a,
+    button {
+      color: white !important;
+
+      @media (--bp-desktop) {
+        color: rgba(255, 255, 255, .8) !important;
+      }
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: white !important;
+
+        @media (--bp-desktop) {
+          color: rgba(255, 255, 255, .8) !important;
+        }
+      }
+    }
+  }
+
+  &__contact {
+    display: none;
+
+    @media (--bp-desktop) {
+      display: block;
+    }
+  }
+
+  &__mobile-menu {
+    @media (--bp-desktop) {
+      display: none;
+    }
+  }
+
+  &__search,
+  &__mobile-menu {
+    button {
+      display: flex;
+      flex-direction: column-reverse;
+      align-items: center;
+
+      @media (--bp-desktop) {
+        flex-direction: row;
+      }
+
+      svg {
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-bottom: .25rem;
+
+        @media (--bp-desktop) {
+          width: .75rem;
+          height: .75rem;
+          margin-left: .25rem;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
+  &__skip-link {
+    display: inline-block;
+  }
+
+  .page-header-search {
+    height: 100%;
+    z-index: 10;
+
+    &__close {
+      display: inline-block;
+      color: rgb(var(--col-brand));
+      text-transform: uppercase;
+      font-size: .6rem;
+      padding: 0 1.5rem;
+
+      svg {
+        margin: 0 auto .2rem;
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+    }
+  }
+}

--- a/components/megamenu/index.css
+++ b/components/megamenu/index.css
@@ -1,3 +1,5 @@
 @import '_mega-menu.css';
 @import '_mega-menu-title.css';
 @import '_mega-menu-top.css';
+@import '_mega-menu-alt.css';
+@import '_mega-menu-alt-mobile.css';

--- a/components/megamenu/stories/MegaMenuAlt.vue
+++ b/components/megamenu/stories/MegaMenuAlt.vue
@@ -1,0 +1,12 @@
+<template>
+  <MegaMenuAlt />
+</template>
+
+<script>
+import MegaMenuAlt from '../MegaMenuAlt.vue';
+
+export default {
+  components: { MegaMenuAlt },
+  readme: { source: true, html: true },
+};
+</script>

--- a/components/megamenu/stories/index.js
+++ b/components/megamenu/stories/index.js
@@ -6,10 +6,11 @@ import HybridMenu from './HybridMenu.vue';
 import HybridMenuProp from './HybridMenuProp.vue';
 import MegaMenuTitle from './MegaMenuTitle.vue';
 import HybridMenuWithTopNav from './HybridMenuWithTopNav.vue';
-// import MegaMenuExpanded from './MegaMenuExpanded.vue';
+import MegaMenuAlt from './MegaMenuAlt.vue';
 
 storiesOf('Mega menu', module)
   .add('Menu / hamburger hybrid', createStory(HybridMenu))
   .add('Mega Menu, populated via prop', createStory(HybridMenuProp))
   .add('Mega Menu Title with Prop', createStory(MegaMenuTitle))
-  .add('Mega Menu with Top nav', createStory(HybridMenuWithTopNav));
+  .add('Mega Menu with Top nav', createStory(HybridMenuWithTopNav))
+  .add('Mega Menu Alt (Today)', createStory(MegaMenuAlt));

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "throttle-debounce": "^2.1.0",
     "vue": "2.6.10",
     "vue-concise-slider": "^3.4.2",
+    "vue-focus-lock": "^1.4.1",
     "vue-progressive-image": "3.2.0",
     "vue-scrollto": "^2.17.1"
   },

--- a/targets/lib/index.js
+++ b/targets/lib/index.js
@@ -121,6 +121,7 @@ import CardsFilterCategory from 'components/filter/cards-category/CardsFilterCat
 import CoursesFilter from 'components/filter/courses/CoursesFilter.vue';
 import PathfinderToday from 'components/today/PathfinderToday/PathfinderToday.vue';
 import QuickLinksAlt from 'components/quick-links-menu/QuickLinksAlt.vue';
+import MegaMenuAlt from 'components/megamenu/MegaMenuAlt.vue';
 
 import { version } from '../../package.json';
 
@@ -252,6 +253,7 @@ Vue.component('pathfinder-today', PathfinderToday);
 Vue.component('quick-links-alt', QuickLinksAlt);
 Vue.component('video-player', VideoPlayer);
 Vue.component('video-full-width', VideoFullWidth);
+Vue.component('mega-menu-alt', MegaMenuAlt);
 
 // Create Vue instance
 new Vue({

--- a/targets/vue/index.js
+++ b/targets/vue/index.js
@@ -490,3 +490,7 @@ export {
   default as QuickLinksAlt,
 }
   from 'components/quick-links-menu/QuickLinksAlt.vue';
+export {
+  default as MegaMenuAlt,
+}
+  from 'components/megamenu/MegaMenuAlt.vue';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5762,6 +5762,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+focus-lock@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.5.4.tgz#537644d61b9e90fd97075aa680b8add1de24e819"
+  integrity sha512-A9ngdb0NyI6UygBQ0eD+p8SpLWTkdEDn67I3EGUUcDUfxH694mLA/xBWwhWhoj/2YLtsv2EoQdAx9UOKs8d/ZQ==
+
 follow-redirects@^1.0.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.1.tgz#514973c44b5757368bad8bddfe52f81f015c94cb"
@@ -14747,6 +14752,13 @@ vue-eslint-parser@^6.0.5:
     espree "^5.0.0"
     esquery "^1.0.1"
     lodash "^4.17.11"
+
+vue-focus-lock@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/vue-focus-lock/-/vue-focus-lock-1.4.1.tgz#db08fdf22c463315210a09abfabc0e7c493fecc1"
+  integrity sha512-Q33bDyy9v+FAsyO0dp7mufOjG8o+O/65/gbiG6BAR4ym6DRAG/za8E2kRj9F8C+s2kbg+Bn/4AFB9Qf+li8i6w==
+  dependencies:
+    focus-lock "^0.5.4"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
# Description

Updated link based on feeback from Brendan:

> Remove Alumni from footer
> Add Safety and respect to the footer (in place of ‘Alumni’)
> Link safety and respect to this page (https://students.unimelb.edu.au/campus-life/policy-and-conduct/respect-at-the-university)

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (IE11, Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11