### PR TITLE
fix(component): mega menu duplicated id with icon-menu

### DIFF
--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -172,9 +172,7 @@
             viewBox="10 10 26 28">
             <path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z" />
           </svg>
-          <span
-            id="icon-menu-text"
-            class="link-icon__text">Menu</span>
+          <span class="link-icon__text">Menu</span>
         </button>
       </div>
     </div>

--- a/components/megamenu/MegaMenu.vue
+++ b/components/megamenu/MegaMenu.vue
@@ -173,7 +173,7 @@
             <path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z" />
           </svg>
           <span
-            id="icon-menu"
+            id="icon-menu-text"
             class="link-icon__text">Menu</span>
         </button>
       </div>


### PR DESCRIPTION
# Description

Fixes https://todaydesign.atlassian.net/browse/UOM18B-171

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Make sure to do not repeat yourself (DRY)
- [x] Snapshots tested
- [x] A11y tested
- [x] CSS utilises BEM naming convention and structure
- [x] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [x] Crossbrowser testing (Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [x] My changes generate no new warnings
- [x] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11