### PR TITLE
fix(accessibility): campaign-banner-alt background contrast

### DIFF
--- a/components/campaign/_campaign-banner-alt.css
+++ b/components/campaign/_campaign-banner-alt.css
@@ -1,5 +1,5 @@
 .campaign-banner-alt {
-  background-color: rgb(var(--col-bg-tertiary-navy));
+  background-color: rgb(var(--col-background-tertiary-navy));
   color: rgb(var(--col-white));
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Accessibility issue
SiteImprove is reporting the header background as white, causing the overlaid text to fail contrast checks as it is also white. The background has been set to dark navy, but this is failing to be set as there is a typo in the CSS var name used.

This is a false positive however, as there is a dark background image plus gradient in the layers between the text and the background, so is highly legible.

<img width="1066" alt="Screen Shot 2021-06-03 at 2 00 05 pm" src="https://user-images.githubusercontent.com/34703139/120584842-08557200-c474-11eb-8ecd-59f8783f56eb.png">

## Solution
- Background colour has been set, but there is a typo in the colour variable name used. This has been corrected and should enable the background colour to be set to dark navy as originally intended, which should resolve this issue.