### PR TITLE
fix(accessibility): Override Normalize styles to browser defaults for Firefox focus rings

### DIFF
--- a/components/_base.css
+++ b/components/_base.css
@@ -187,6 +187,14 @@ textarea {
   line-height: inherit;
 }
 
+/* Remove Normalize override styles for Firefox focus rings */
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring,
+button:-moz-focusring {
+  outline: revert;
+}
+
 button {
   border: none;
   background: none;


### PR DESCRIPTION
## Currently
<img width="863" alt="Screen Shot 2021-06-03 at 2 48 51 pm" src="https://user-images.githubusercontent.com/34703139/120588868-4b671380-c47b-11eb-8722-ea1d034398e0.png">

The `Normalize.css` included in the pattern-lib build resets the default focus styling for Firefox to a single black dotted line on certain button/input elements. This renders it very difficult to see on dark backgrounds.

Reported as an accessibility issue:


> Problem
> Tabs that have focus do not have borders on the right or the bottom
> SortSite is complaining about the tab borders not being visible
> Solution
> See if the outline-width and button border styles can be made visible


## Solution
I've `revert`ed this Normalize change in our `base.css`, so these properties should come from the Firefox user agent stylesheet (browser defaults) instead.

<img width="265" alt="Screen Shot 2021-06-03 at 2 55 57 pm" src="https://user-images.githubusercontent.com/34703139/120589506-48b8ee00-c47c-11eb-8902-5bd4d2b311c6.png">
