### PR TITLE
Fix padding for sections in succession

### DIFF
--- a/components/section/_section-alt.css
+++ b/components/section/_section-alt.css
@@ -6,7 +6,7 @@
     background-color: rgb(var(--col-grey-light));
   }
 
-  &[class~='section-alt'] + [class~='section-alt'] &__inner {
+  &:not([class~='section-alt--bordered']):not([class~='section-alt--bg-grey-light']):not([class~='section-alt--iimg']) + &:not([class~='section-alt--bordered']):not([class~='section-alt--bg-grey-light']):not([class~='section-alt--img']) &__inner {
     padding-top: 0;
 
     @media (--bp-wide) {

--- a/components/section/_section-alt.css
+++ b/components/section/_section-alt.css
@@ -6,7 +6,7 @@
     background-color: rgb(var(--col-grey-light));
   }
 
-  &:not([class~='section-alt--bordered']):not([class~='section-alt--bg-grey-light']):not([class~='section-alt--iimg']) + &:not([class~='section-alt--bordered']):not([class~='section-alt--bg-grey-light']):not([class~='section-alt--img']) &__inner {
+  &:not([class*='section-alt--']) + &:not([class*='section-alt--']) &__inner {
     padding-top: 0;
 
     @media (--bp-wide) {


### PR DESCRIPTION
# Description

Update the selector to fix padding on sections when two sections with just a white background are used in succession. The previous selector was applying to all sections, see https://find-a-course-preview-staging.netlify.app/find/micro-credentials/cybersecurity-technologies-for-defence/ (broken padding on mobile and reduced on desktop)

The selector is a bit ugly - initially I was trying to be a bit clever and not have to have say a default class of `section-alt--standard` but maybe that is easier. That would require a change though I presume to existing components in Matrix.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11