### PR TITLE
fix(accessibility): Add left border to notices to meet non-text contrast requirements

### DIFF
--- a/components/notice/index.css
+++ b/components/notice/index.css
@@ -3,9 +3,11 @@
   padding: var(--vr);
   border-radius: 4px;
   background-color: rgb(var(--col-navy-light));
+  border-left: .375rem solid rgb(var(--col-blue-mid-2));
 
   &--warning {
     background-color: rgb(var(--col-orange-light));
+    border-left: .375rem solid rgb(var(--col-orange-dark));
     color: color-mod(rgb(var(--col-orange-mid-2)) lightness(25%));
 
     a {
@@ -15,6 +17,7 @@
 
   &--success {
     background-color: rgb(var(--col-green-light));
+    border-left: .375rem solid rgb(var(--col-green-dark));
     color: color-mod(rgb(var(--col-green-mid-2)) lightness(25%));
 
     a {
@@ -24,6 +27,7 @@
 
   &--danger {
     background-color: rgb(var(--col-orange-dark));
+    border-left: .375rem solid rgb(var(--col-pink-dark));
     color: rgb(var(--col-background-primary-white));
 
     a {


### PR DESCRIPTION
- Adds a left border with contrast greater than 3:1 to the notice components in order to comply with [WCAG non-text contrast requirements](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).

<img width="821" alt="Screen Shot 2021-06-25 at 12 21 59 pm" src="https://user-images.githubusercontent.com/34703139/123359250-4ac02980-d5b0-11eb-9024-f78a79829541.png">
