### PR TITLE
Fix and improvements - homepage components

### DIFF
--- a/components/campaign/CampaignBannerAlt.vue
+++ b/components/campaign/CampaignBannerAlt.vue
@@ -79,7 +79,7 @@ export default {
     },
     subHeading: {
       type: String,
-      required: true,
+      required: false,
       default: '',
     },
     tag: {

--- a/components/campaign/CampaignBannerAlt.vue
+++ b/components/campaign/CampaignBannerAlt.vue
@@ -31,6 +31,11 @@
           </a>
           {{ title }}
         </h1>
+        <p
+          v-if="subHeading"
+          class="heading-sm">
+          {{ subHeading }}
+        </p>
         <ul
           v-if="links && links.length"
           class="campaign-banner-alt__links list-reset">
@@ -68,6 +73,11 @@ export default {
   },
   props: {
     title: {
+      type: String,
+      required: true,
+      default: '',
+    },
+    subHeading: {
       type: String,
       required: true,
       default: '',

--- a/components/campaign/__tests__/__snapshots__/CampaignBannerAlt.test.js.snap
+++ b/components/campaign/__tests__/__snapshots__/CampaignBannerAlt.test.js.snap
@@ -34,6 +34,8 @@ exports[`CampaignBannerAlt should match snapshot 1`] = `
       </h1>
        
       <!---->
+       
+      <!---->
     </div>
   </div>
 </div>
@@ -71,6 +73,8 @@ exports[`CampaignBannerAlt should match snapshot with button 1`] = `
         Register now for Open Days 2021
       
       </h1>
+       
+      <!---->
        
       <!---->
     </div>

--- a/components/cards/CardFlat.vue
+++ b/components/cards/CardFlat.vue
@@ -18,13 +18,20 @@
       </ButtonIcon>
     </div>
     <div
+      v-if="video"
+      class="card-flat__img">
+      <VideoEmbed
+        video-api
+        :src="video.src" />
+    </div>
+    <div
       v-if="img"
       class="card-flat__img">
       <client-only>
         <progressive-img
           :src="img.src"
           :alt="img.alt || ''"
-          :aspect-ratio="0.6"
+          :aspect-ratio="0.56"
           class="card-flat__img-inner" />
       </client-only>
     </div>
@@ -33,10 +40,12 @@
 
 <script>
 import ButtonIcon from 'components/buttons/ButtonIcon.vue';
+import VideoEmbed from 'components/embed/VideoEmbed.vue';
 
 export default {
   components: {
     ButtonIcon,
+    VideoEmbed,
   },
   props: {
     title: {
@@ -56,9 +65,14 @@ export default {
         return null;
       },
     },
+    video: {
+      type: Object,
+      default() {
+        return null;
+      },
+    },
     img: {
       type: Object,
-      required: true,
       default() {
         return null;
       },

--- a/components/cards/CardFlat.vue
+++ b/components/cards/CardFlat.vue
@@ -21,7 +21,7 @@
       v-if="video"
       class="card-flat__img">
       <VideoEmbed
-        video-api
+        :video-api="video.videoApi"
         :src="video.src" />
     </div>
     <div

--- a/components/cards/__tests__/__snapshots__/CardFlat.test.js.snap
+++ b/components/cards/__tests__/__snapshots__/CardFlat.test.js.snap
@@ -17,5 +17,7 @@ exports[`CardFlat should match snapshot 1`] = `
   <!---->
    
   <!---->
+   
+  <!---->
 </div>
 `;

--- a/components/cards/__tests__/__snapshots__/CardFlatList.test.js.snap
+++ b/components/cards/__tests__/__snapshots__/CardFlatList.test.js.snap
@@ -65,13 +65,15 @@ exports[`CardFlatList should match snapshot 1`] = `
         </a>
       </div>
        
+      <!---->
+       
       <div
         class="card-flat__img"
       >
         <client-only>
           <progressive-img
             alt="Image for example purposes."
-            aspect-ratio="0.6"
+            aspect-ratio="0.56"
             class="card-flat__img-inner"
             src="https://picsum.photos/seed/1/540/360"
           />
@@ -140,13 +142,15 @@ exports[`CardFlatList should match snapshot 1`] = `
         </a>
       </div>
        
+      <!---->
+       
       <div
         class="card-flat__img"
       >
         <client-only>
           <progressive-img
             alt="Image for example purposes."
-            aspect-ratio="0.6"
+            aspect-ratio="0.56"
             class="card-flat__img-inner"
             src="https://picsum.photos/seed/1/540/360"
           />
@@ -215,13 +219,15 @@ exports[`CardFlatList should match snapshot 1`] = `
         </a>
       </div>
        
+      <!---->
+       
       <div
         class="card-flat__img"
       >
         <client-only>
           <progressive-img
             alt="Image for example purposes."
-            aspect-ratio="0.6"
+            aspect-ratio="0.56"
             class="card-flat__img-inner"
             src="https://picsum.photos/seed/1/540/360"
           />
@@ -290,13 +296,15 @@ exports[`CardFlatList should match snapshot 1`] = `
         </a>
       </div>
        
+      <!---->
+       
       <div
         class="card-flat__img"
       >
         <client-only>
           <progressive-img
             alt="Image for example purposes."
-            aspect-ratio="0.6"
+            aspect-ratio="0.56"
             class="card-flat__img-inner"
             src="https://picsum.photos/seed/1/540/360"
           />

--- a/components/embed/VideoEmbed.vue
+++ b/components/embed/VideoEmbed.vue
@@ -72,7 +72,7 @@ export default {
     },
     returnVideoUrlApi() {
       if (this.videoApi) {
-        return `${this.src}?enablejsapi=1&origin=https%3A%2F%2F${document.location.hostname}.unimelb.edu.au`;
+        return `${this.src}?enablejsapi=1&rel=0&origin=https%3A%2F%2F${document.location.hostname}.unimelb.edu.au`;
       }
       return this.src;
     },

--- a/components/embed/VideoPlayer.vue
+++ b/components/embed/VideoPlayer.vue
@@ -56,7 +56,7 @@
       <iframe
         v-else-if="videoPlaying"
         ref="embed"
-        title="Youtube video"
+        :title="label"
         width="560"
         height="315"
         :src="videoSrc"

--- a/components/today/stories/Campaign/Default.vue
+++ b/components/today/stories/Campaign/Default.vue
@@ -1,6 +1,7 @@
 <template>
   <CampaignBannerAlt
     :title="title"
+    :sub-heading="subHeading"
     :cta="cta"
     :img="img" />
 </template>
@@ -20,6 +21,7 @@ export default {
   data() {
     return {
       title: 'Register now for Open Days 2021',
+      subHeading: 'Sunday 4 July–Sunday 11 July',
       img: {
         src: campaignHeroDesktopImage,
         alt: 'Woman typing on laptop',

--- a/components/today/stories/Campaign/Event.vue
+++ b/components/today/stories/Campaign/Event.vue
@@ -1,6 +1,7 @@
 <template>
   <CampaignBannerAlt
     :title="title"
+    sub-heading="Sunday 4 July–Sunday 11 July"
     :cta="cta"
     :img="img"
     :tag="tag"

--- a/components/today/stories/Campaign/Large.vue
+++ b/components/today/stories/Campaign/Large.vue
@@ -1,6 +1,7 @@
 <template>
   <CampaignBannerAlt
     :title="title"
+    sub-heading="Sunday 4 July–Sunday 11 July"
     :cta="cta"
     :img="img"
     size="lg" />

--- a/components/today/stories/Campaign/LargeWithLinks.vue
+++ b/components/today/stories/Campaign/LargeWithLinks.vue
@@ -1,6 +1,7 @@
 <template>
   <CampaignBannerAlt
     :title="title"
+    sub-heading="Sunday 4 July–Sunday 11 July"
     :links="links"
     :img="img"
     size="lg" />

--- a/components/today/stories/Campaign/campaign-banner-alt.md
+++ b/components/today/stories/Campaign/campaign-banner-alt.md
@@ -6,6 +6,7 @@ The component `CampaignBannerAlt` acceps the following props:
 | props    	| type    	|
 |----------	|---------	|
 | title   	| String  	|
+| sub-heading   	| String  	|
 | tag      	| Object  	|
 | text 	    | String   	|
 | img     	| Object  	|
@@ -17,6 +18,7 @@ The component `CampaignBannerAlt` acceps the following props:
 ```html
 <campaign-banner-alt
   title="Register now for Open Days 2021"
+  sub-heading="Sunday 4 July–Sunday 11 July"
   :cta="{
     text: 'Register now',
     href: '#',

--- a/components/today/stories/Cards/CardFlat.md
+++ b/components/today/stories/Cards/CardFlat.md
@@ -2,11 +2,28 @@
 
 #### Usage:
 
+this component accept an image or video as a prop:
+
+| props    	   | type    	|
+|------------- |---------	|
+| title    	   | String  	|
+| description     | String   |
+| cta  | Object   |
+| img          | Object   |
+| video          | Object   |
+
 ```html
   <card-flat
     title="Test Title"
     description="Consectetur culpa nostrud officia consequat ut mollit elit aliquip nisi consequat occaecat quis excepteur."
     :cta="{ href: 'https://www.unimelb.edu.au/', text: 'Cta button' }"
     :img="{ src: 'https://picsum.photos/seed/1/540/360', alt: 'Image for example purposes.' }" >
+    </card-flat>
+
+      <card-flat
+    title="Test Title"
+    description="Consectetur culpa nostrud officia consequat ut mollit elit aliquip nisi consequat occaecat quis excepteur."
+    :cta="{ href: 'https://www.unimelb.edu.au/', text: 'Cta button' }"
+    :video="{ src: 'https://player.vimeo.com/video/566879573' }" >
     </card-flat>
 ```

--- a/components/today/stories/Cards/CardFlat.md
+++ b/components/today/stories/Cards/CardFlat.md
@@ -24,6 +24,6 @@ this component accept an image or video as a prop:
     title="Test Title"
     description="Consectetur culpa nostrud officia consequat ut mollit elit aliquip nisi consequat occaecat quis excepteur."
     :cta="{ href: 'https://www.unimelb.edu.au/', text: 'Cta button' }"
-    :video="{ src: 'https://player.vimeo.com/video/566879573' }" >
+    :video="{ src: 'https://player.vimeo.com/video/566879573', videoApi: true }" >
     </card-flat>
 ```

--- a/components/today/stories/Cards/CardFlatList.md
+++ b/components/today/stories/Cards/CardFlatList.md
@@ -18,7 +18,7 @@ this component accept an image or video as a prop:
           title: 'Our campuses',
           description: 'Located a short walk from central Melbourne, our main campus anchors a network of three urban innovation precincts and six specialist campuses located throughout Victoria.',
           cta: { href: 'https://www.unimelb.edu.au/', text: 'Virtual campus tours' },
-          video: { src: 'https://player.vimeo.com/video/566879573' },
+          video: { src: 'https://player.vimeo.com/video/566879573', videoApi: false },
         },
         {
           title: 'Research facilities',

--- a/components/today/stories/Cards/CardFlatList.md
+++ b/components/today/stories/Cards/CardFlatList.md
@@ -2,13 +2,23 @@
 
 #### Usage:
 
+this component accept an image or video as a prop:
+
+| props    	   | type    	|
+|------------- |---------	|
+| title    	   | String  	|
+| description     | String   |
+| cta  | Object   |
+| img          | Object   |
+| video          | Object   |
+
 ```html
   <card-flat-list :items="[
         {
           title: 'Our campuses',
           description: 'Located a short walk from central Melbourne, our main campus anchors a network of three urban innovation precincts and six specialist campuses located throughout Victoria.',
           cta: { href: 'https://www.unimelb.edu.au/', text: 'Virtual campus tours' },
-          img: { src: 'https://picsum.photos/seed/1/540/360', alt: 'Image for example purposes.' },
+          video: { src: 'https://player.vimeo.com/video/566879573' },
         },
         {
           title: 'Research facilities',

--- a/components/today/stories/Cards/CardFlatList.vue
+++ b/components/today/stories/Cards/CardFlatList.vue
@@ -19,7 +19,7 @@ export default {
           title: 'Our campuses',
           description: 'Located a short walk from central Melbourne, our main campus anchors a network of three urban innovation precincts and six specialist campuses located throughout Victoria.',
           cta: { href: 'https://www.unimelb.edu.au/', text: 'Virtual campus tours' },
-          video: { src: 'https://player.vimeo.com/video/566879573' },
+          video: { src: 'https://player.vimeo.com/video/566879573', videoApi: false },
         },
         {
           title: 'Research facilities',

--- a/components/today/stories/Cards/CardFlatList.vue
+++ b/components/today/stories/Cards/CardFlatList.vue
@@ -19,7 +19,7 @@ export default {
           title: 'Our campuses',
           description: 'Located a short walk from central Melbourne, our main campus anchors a network of three urban innovation precincts and six specialist campuses located throughout Victoria.',
           cta: { href: 'https://www.unimelb.edu.au/', text: 'Virtual campus tours' },
-          img: { src: 'https://picsum.photos/seed/1/540/360', alt: 'Image for example purposes.' },
+          video: { src: 'https://player.vimeo.com/video/566879573' },
         },
         {
           title: 'Research facilities',


### PR DESCRIPTION
# Description

 
## Video iframe incorrectly titled
The video component takes these parameters (label="Life at Melbourne"):
Graphical user interface, text, application, chat or text message

Description automatically generated
But outputs this iframe code (title="Youtube video)":
Text

Description automatically generated with low confidence
The title attribute of the iframe should reflect the label property

## Campaign Banner requires subtitle
an H1 and a link are not sufficient for Campaign Banners.
eg. in the case of Open Day, we'd want something like:
Open Day
August 10, 2021
[ Join us ]
I have resolved this within our CMS https://www.unimelb.edu.au/?banner=3822735, but the pattern should probably be rolled back into the vue component with a property to generate the subheading.

## Card Article with video
A last minute request saw us add a video to a card in place of an image. (First card in last section of the page)
Because the page is maintained largely as static html, this wasn't terribly difficult and worked surprisingly well apart from a couple of small wrinkles.

1) Aspect ratio of the video is slightly different to an image, with the result that the top of the element, as well as the cta link are slightly misaligned when beside a standard image card. Whether it's a matter of making the sizes consistent, letterboxing the video, or some other solution doesn't matter. There’s also a slight problem in that there’s a 1 pixel border on the right of the small embedded video.

2) In this small format, the SVG controls/labels are rather large. Would be nice if they could be a little more proportionally sized. Especially the ‘close’ button, which could maybe be semi transparent when the video is playing or only appear on hover.

Initially, the video was inserted as standard embed code, but I'm hoping to get the OK to switch to using the video component, (though it would be even better if the other issues regarding video embed components - title and autoplay - could be resolved).
At the moment, to see the vue component version of the video, you need to load https://www.unimelb.edu.au?preview=video
Of course, it then follows that the video option would need to be incorporated into the parent card component, and so on. Complicated, I know.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] Make sure to do not repeat yourself (DRY)
- [ ] Snapshots tested
- [ ] A11y tested
- [ ] CSS utilises BEM naming convention and structure
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] Crossbrowser testing (Safari 8+, iOS 8.4+, Android 4.4+, Firefox ESR (v52.x), iPhone (4s,6), iPad 2, Galaxy s5) 
- [ ] My changes generate no new warnings
- [ ] I have added tests (e2e and unit) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Added the new component to the index.js (Vue and Lib) export

# Reviewer Checklist

- [ ] Code is not repeated (DRY)
- [ ] ES6+ code is used where possible
- [ ] Code does not mutate variables/objects/arrays but instead uses `map`, `filter` etc to return a new array/object
- [ ] CSS utilises BEM naming convention and structure
- [ ] Snapshots tested against a copy of dev snapshots to check UI changes are intended
- [ ] A11y tested
- [ ] Crossbrowser tested in at least IE11